### PR TITLE
feat(designer_v2): RLS improvements

### DIFF
--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -3,7 +3,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_core/core.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../models/app_state.dart';
@@ -79,13 +78,15 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
               child: Material(child: StudyTile.fromStudy(study: study)),
             ),
             const SizedBox(height: 16),
+            /* todo why is this here?
             RetryFutureBuilder<Study>(
               tryFunction: () => SupabaseQuery.getById<Study>(study.id),
               successBuilder: (BuildContext context, Study study) {
                 context.read<AppState>().selectedStudy = study;
                 return StudyDetailsView(study: study);
               },
-            ),
+            ), */
+            StudyDetailsView(study: study),
           ],
         ),
       ),

--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -78,14 +78,6 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
               child: Material(child: StudyTile.fromStudy(study: study)),
             ),
             const SizedBox(height: 16),
-            /* todo why is this here?
-            RetryFutureBuilder<Study>(
-              tryFunction: () => SupabaseQuery.getById<Study>(study.id),
-              successBuilder: (BuildContext context, Study study) {
-                context.read<AppState>().selectedStudy = study;
-                return StudyDetailsView(study: study);
-              },
-            ), */
             StudyDetailsView(study: study),
           ],
         ),

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -140,9 +140,10 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
             label: Text(AppLocalizations.of(context).next),
             onPressed: () async {
               final res = await Supabase.instance.client
-                  .rpc('get_study_from_invite', params: {'invite_code': _controller.text})
-                  .single()
-                  .execute();
+                  .rpc('get_study_from_invite',
+                  params: {'invite_code': _controller.text},
+              ).single().execute();
+
               if (res.error != null) {
                 print(res.error.message);
                 setState(() {

--- a/core/lib/src/models/tables/study.dart
+++ b/core/lib/src/models/tables/study.dart
@@ -130,7 +130,6 @@ class Study extends SupabaseObjectFunctions<Study> {
         await env.client
             .from(tableName)
             .select()
-            .eq('participation', 'open')
             .execute(),
       );
 

--- a/database/studyu-schema.sql
+++ b/database/studyu-schema.sql
@@ -742,10 +742,10 @@ CREATE POLICY "Editors can see their study subjects progress" ON public.subject_
 
 
 --
--- Name: study Everybody can view published studies; Type: POLICY; Schema: public; Owner: supabase_admin
+-- Name: study Everybody can view (published and open) studies; Type: POLICY; Schema: public; Owner: supabase_admin
 --
 
-CREATE POLICY "Everybody can view published studies" ON public.study FOR SELECT USING ((published = true));
+CREATE POLICY "Everybody can view (published and open) studies" ON public.study FOR SELECT USING ((published = true) AND (participation = 'open'::public.participation));
 
 
 --

--- a/database/studyu-schema.sql
+++ b/database/studyu-schema.sql
@@ -74,7 +74,7 @@ SET default_table_access_method = heap;
 --
 
 CREATE TABLE public.study (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     contact jsonb NOT NULL,
     title text NOT NULL,
     description text NOT NULL,
@@ -112,7 +112,7 @@ COMMENT ON COLUMN public.study.user_id IS 'UserId of study creator';
 --
 
 CREATE TABLE public.study_subject (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     study_id uuid NOT NULL,
     user_id uuid NOT NULL,
     started_at timestamp with time zone DEFAULT now(),

--- a/designer_v2/lib/constants.dart
+++ b/designer_v2/lib/constants.dart
@@ -1,5 +1,3 @@
-
-
 class Config {
   static const isDebugMode = true;
 

--- a/designer_v2/lib/features/auth/signup_page.dart
+++ b/designer_v2/lib/features/auth/signup_page.dart
@@ -6,7 +6,9 @@ import 'package:studyu_designer_v2/common_views/primary_button.dart';
 import 'package:studyu_designer_v2/features/auth/auth_controller.dart';
 import 'package:studyu_designer_v2/features/auth/form_controller.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/localization/locale_providers.dart';
 import 'package:studyu_designer_v2/localization/string_hardcoded.dart';
+import 'package:studyu_designer_v2/repositories/app_repository.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'auth_formfield_views.dart';
@@ -73,7 +75,9 @@ class _PageContentState extends ConsumerState<PageContent> {
   }
 
   Widget _tosWidget() {
-    // .hardcoded see below
+    final appConfig = ref.watch(appConfigProvider);
+    final locale = ref.watch(localeProvider);
+    appConfig.maybeWhen(data: (value) => print(value.contact), orElse: () => print("null"));
     return ReactiveCheckboxListTile(
       formControlName: 'termsOfService',
       //onChanged: (val) => authForm.control('termsOfService').value = val.value,
@@ -88,7 +92,7 @@ class _PageContentState extends ConsumerState<PageContent> {
               text: 'terms of use',
               style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
               recognizer: TapGestureRecognizer()
-                ..onTap = () { launchUrl(Uri.parse('https://www13.hpi.uni-potsdam.de/fileadmin/user_upload/fachgebiete/lippert/studyu/StudyU_Designer_terms_en.pdf'.hardcoded)); },
+                ..onTap = () { launchUrl(appConfig.maybeWhen(data: (value) => Uri.parse(value.designerTerms[locale.languageCode] ?? ""), orElse: () => Uri.parse(''))); },
             ),
             const TextSpan(
               text: ' and ',
@@ -97,7 +101,7 @@ class _PageContentState extends ConsumerState<PageContent> {
               text: 'privacy policy',
               style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
               recognizer: TapGestureRecognizer()
-                ..onTap = () { launchUrl(Uri.parse('https://www13.hpi.uni-potsdam.de/fileadmin/user_upload/fachgebiete/lippert/studyu/StudyU_Designer_privacy_en.pdf'.hardcoded)); },
+                ..onTap = () { launchUrl(appConfig.maybeWhen(data: (value) => Uri.parse(value.designerPrivacy[locale.languageCode] ?? ""), orElse: () => Uri.parse(''))); },
             ),
             const TextSpan(
               text: ' ', // Prevent clickable area stretching

--- a/designer_v2/lib/features/study/study_test_controller.dart
+++ b/designer_v2/lib/features/study/study_test_controller.dart
@@ -28,21 +28,21 @@ abstract class PlatformController {
 }
 
 class StudyTestController extends StateNotifier<StudyTestState> {
-  String previewSrc = appDeepLink;
-
+  final Study study;
   final IAuthRepository authRepository;
   late PlatformController platformController;
-  final Study study;
+  late String previewSrc;
 
   StudyTestController({
     required this.study,
     required this.authRepository,
   }) : super(StudyTestState(currentUser: authRepository.currentUser!)) {
     List<dynamic> missingRequirements = _missingRequirements();
+    previewSrc = "$appDeepLink?";
     if (missingRequirements.isEmpty) {
       // requirements satisfied
       String sessionStr = authRepository.session?.persistSessionString ?? '';
-      previewSrc += '?mode=preview&session=${Uri.encodeComponent(sessionStr)}&studyid=${study.id}';
+      previewSrc += '&mode=preview&session=${Uri.encodeComponent(sessionStr)}&studyid=${study.id}';
     } else {
       // todo show modal and add error
       if (kDebugMode) {

--- a/flutter_common/lib/envs/.env.staging
+++ b/flutter_common/lib/envs/.env.staging
@@ -1,4 +1,4 @@
-STUDYU_SUPABASE_URL=https://rzxnjlfzycwnaayubbeo.supabase.co
-STUDYU_SUPABASE_PUBLIC_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ6eG5qbGZ6eWN3bmFheXViYmVvIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NTY1MTM1MTcsImV4cCI6MTk3MjA4OTUxN30.OGqe_zCQIUImHc5YwN5S0PljMTdhT4Jtb8VK9eGtE-4
+STUDYU_SUPABASE_URL=https://upxjzmfhjwyxulaxohyg.supabase.co
+STUDYU_SUPABASE_PUBLIC_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVweGp6bWZoand5eHVsYXhvaHlnIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NjA2NjQ1MzMsImV4cCI6MTk3NjI0MDUzM30.P8CaJ6a0bQzqS54aEzFVhv9tc57-vXJ6SbcQrL_YuAQ
 STUDYU_PROJECT_GENERATOR_URL=https://studyu-project-generator-2zro3rzera-ew.a.run.app
-STUDYU_APP_URL="https://studyu-app.web.app/#/"
+STUDYU_APP_URL="https://studyu-app-v2.web.app/#/"


### PR DESCRIPTION
### Extensive testing needed. Due to its breaking nature, this PR is incompatible with the current state of the database. We have to test and deploy this to a separate database.

---

This PR makes modifications to the database schema and necessary code adaptions.

Database changes:

- [x] For non-editors, Studies are now visible if they are published **and the participation is set to open**
- [x] If a user is added as a study subject for the respective study, they may also get permissive view (SELECT) permissions
- [x] Adds a RPC supabase function to retrieve study information if a correct invite code is given

Code changes:

- [x] App: Use the RPC when joining a study via an invitation

---

Notice: This PR has to be tested in another environment. This can be achieved by adding "--dart-define=ENV=.env.staging" into the "Additional run args" field in the Run/Debug Configuration in Android Studio for the App and the Designer. **The preview links on Github will NOT work!**