### PR TITLE
Docker Volumes For Supabase Deployment

### DIFF
--- a/docker/supabase/docker-compose-db.yml
+++ b/docker/supabase/docker-compose-db.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 name: 'studyu'
 
 services:
@@ -37,6 +37,8 @@ services:
       # Must be superuser to alter reserved role
       - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:Z
       # PGDATA directory is persisted between restarts
-      - ./volumes/db/data:/var/lib/postgresql/data:Z
+      - studyu-dbdata:/var/lib/postgresql/data:Z
       # Init sql data
       - ../../database/studyu-schema.sql:/docker-entrypoint-initdb.d/init-scripts/99-data.sql:Z
+volumes:
+  studyu-dbdata:

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -193,7 +193,7 @@ services:
       ENABLE_IMAGE_TRANSFORMATION: "true"
       IMGPROXY_URL: http://imgproxy:5001
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - studyu-blob:/var/lib/storage:z
 
   imgproxy:
     container_name: supabase-imgproxy
@@ -209,7 +209,7 @@ services:
       IMGPROXY_USE_ETAG: "true"
       IMGPROXY_ENABLE_WEBP_DETECTION: ${IMGPROXY_ENABLE_WEBP_DETECTION}
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - studyu-blob:/var/lib/storage:z
 
   meta:
     container_name: supabase-meta
@@ -244,3 +244,5 @@ services:
       - /home/deno/functions/main
 
 # If you want to use logging, please run with `docker compose -f docker-compose.yml -f docker-compose-logging.yml up`
+volumes:
+  studyu-blob:


### PR DESCRIPTION
Currently, the Supabase backend is deployed with docker-compose whereby, all persistent data is stored in directories on the host machine. 
Docker provides a convenient way to persist data in so-called volumes. Thereby, we do not have to take care about where the productive data lives inside the file tree of the repository during updating the deployment. We introduce these volumes for storing all postgres and Supabase blob storage data.