### PR TITLE
Fix UML docs concurrency

### DIFF
--- a/.github/workflows/db-docs.yml
+++ b/.github/workflows/db-docs.yml
@@ -10,6 +10,11 @@ on:
       - 'database/**'
       - 'docker/supabase/**'
 
+concurrency:
+  group: ${{ github.ref }}-db-docs
+  cancel-in-progress: true
+
+
 jobs:
   generate-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/uml-docs.yml
+++ b/.github/workflows/uml-docs.yml
@@ -12,6 +12,10 @@ on:
       - 'designer_v2/**/*.dart'
       - 'app/**/*.dart'
 
+concurrency:
+  group: ${{ github.ref }}-uml-docs
+  cancel-in-progress: true
+
 jobs:
   generate-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Without this multiple docs updates can run at the same time for the same PR and the oldest one can finish last if we get unlucky → incorrect docs & the UML one gets super confused with its change detection because it relies on the latest docs changes to be up to date with all code before that commit

Close #486