### PR TITLE
Git: Normalize line endings to LF for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,11 @@
 # to native line endings on checkout.
 *.c text
 *.h text
+*.dart text
+*.sh text
+*.sql text
+*.md text
+*.svg text -diff
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
@@ -12,3 +17,8 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+*.svg binary
+
+# Files that should be ignored for the repository's language statistics and hidden by default in diffs.
+docs/database/** linguist-generated=true
+docs/uml/** linguist-generated=true


### PR DESCRIPTION
This fixes the issue with generated files that have the same content but different line endings.