### PR TITLE
fix: foreground color of complete button

### DIFF
--- a/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
+++ b/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
@@ -56,7 +56,9 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
           ),
           if (response != null && responseValidator)
             ElevatedButton.icon(
-              style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.green)),
+              style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
+                  foregroundColor: MaterialStateProperty.all<Color>(Colors.white)),
               onPressed: () async {
                 if (isRedundantClick(loginClickTime)) {
                   return;


### PR DESCRIPTION
The complete button looked like this:
![image](https://github.com/hpi-studyu/studyu/assets/7386016/a79bb8cd-cbe9-4f94-9e57-9c892377e21d)

So I changed the foreground color to white.