### PR TITLE
chore: only sign if keystore file is present

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -69,21 +69,17 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
     buildTypes {
         release {
-            signingConfigs {
-                release {
-                    keyAlias keystoreProperties['keyAlias']
-                    keyPassword keystoreProperties['keyPassword']
-                    storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
-                    storePassword keystoreProperties['storePassword']
-                }
-            }
-            buildTypes {
-                release {
-                    signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
-                }
-            }
+            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
         }
     }
 }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -81,12 +81,9 @@ android {
             }
             buildTypes {
                 release {
-                    signingConfig signingConfigs.release
+                    signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
                 }
             }
-
-            // Signing with the debug keys, so `flutter run --release` works.
-            // signingConfig signingConfigs.debug
         }
     }
 }


### PR DESCRIPTION
- Only sign app if a keystore file is present, otherwise create unsigned builds