### PR TITLE
fix: Next day button broken in preview/debug mode

### DIFF
--- a/core/lib/src/models/tables/study_subject.dart
+++ b/core/lib/src/models/tables/study_subject.dart
@@ -291,8 +291,9 @@ class StudySubject extends SupabaseObjectFunctions<StudySubject> {
         .where((p) => p.result.result is QuestionnaireState)
         .map((p) => (p.result.result as QuestionnaireState).answers.values)
         .expand((answers) => answers)
-        .where((e) =>
-            e.question == AudioRecordingQuestion.questionType || e.question == ImageCapturingQuestion.questionType)
+        .where(
+          (e) => e.question == AudioRecordingQuestion.questionType || e.question == ImageCapturingQuestion.questionType,
+        )
         .map((e) => e.response!.toString())
         .toList();
 

--- a/core/lib/src/models/tables/study_subject.dart
+++ b/core/lib/src/models/tables/study_subject.dart
@@ -286,15 +286,13 @@ class StudySubject extends SupabaseObjectFunctions<StudySubject> {
       rethrow;
     }
 
-    final List<Answer> answers = progress
+    // Filter out all multimodal answers and remove their paths from the blob storage
+    final observationPaths = progress
+        .where((p) => p.result.result is QuestionnaireState)
         .map((p) => (p.result.result as QuestionnaireState).answers.values)
         .expand((answers) => answers)
-        .toList();
-
-    final List<String> observationPaths = answers
-        .where(
-          (e) => e.question == AudioRecordingQuestion.questionType || e.question == ImageCapturingQuestion.questionType,
-        )
+        .where((e) =>
+            e.question == AudioRecordingQuestion.questionType || e.question == ImageCapturingQuestion.questionType)
         .map((e) => e.response!.toString())
         .toList();
 


### PR DESCRIPTION
The next day button did not work when a intervention was filled out, because the bool result of the intervention is not a `QuestionnaireState`. This lead to an exception and no entries were deleted. This PR includes a check again this type of error: `.where((p) => p.result.result is QuestionnaireState)`

- [ ] Create a new release for `core` package before merging this