### PR TITLE
fix(designer): Refresh dashboard study table on pin change

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -24,14 +24,11 @@ class DashboardScreen extends ConsumerStatefulWidget {
 }
 
 class _DashboardScreenState extends ConsumerState<DashboardScreen> {
-  late Future<StudyUUser> user;
-
   @override
   void initState() {
     super.initState();
     final controller = ref.read(dashboardControllerProvider.notifier);
     runAsync(() => controller.setStudiesFilter(widget.filter));
-    user = runAsync(() => ref.watch(userRepositoryProvider).fetchUser());
   }
 
   @override
@@ -86,7 +83,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
           ),
           const SizedBox(height: 24.0), // spacing between body elements
           FutureBuilder<StudyUUser>(
-            future: user,
+            future: ref.read(userRepositoryProvider).fetchUser(),
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 return AsyncValueWidget<List<Study>>(

--- a/designer_v2/lib/features/dashboard/dashboard_state.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_state.dart
@@ -52,9 +52,10 @@ class DashboardState extends Equatable {
       data: (studies) {
         List<Study> updatedStudies =
             studiesFilter.apply(studies: studies, user: currentUser).toList();
-        updatedStudies = filter(studiesToFilter: updatedStudies);
-        updatedStudies =
-            sort(pinnedStudies: pinnedStudies, studiesToSort: updatedStudies);
+        updatedStudies = sort(
+          pinnedStudies: pinnedStudies,
+          studiesToSort: filter(studiesToFilter: updatedStudies),
+        );
         return AsyncValue.data(updatedStudies);
       },
       error: (error, _) => AsyncValue.error(error, StackTrace.current),


### PR DESCRIPTION
Designer dashboard study table did not show changes instantly, when studies were pinned/unpinned. This should be fixed now.