### PR TITLE
fix: test sceen validation banner

### DIFF
--- a/designer_v2/lib/features/design/interventions/intervention_form_controller.dart
+++ b/designer_v2/lib/features/design/interventions/intervention_form_controller.dart
@@ -54,9 +54,15 @@ class InterventionFormViewModel
 
   @override
   FormValidationConfigSet get sharedValidationConfig => {
-        StudyFormValidationSet.draft: [titleRequired, atLeastOneTask],
-        StudyFormValidationSet.publish: [titleRequired, atLeastOneTask],
-        StudyFormValidationSet.test: [titleRequired, atLeastOneTask],
+        StudyFormValidationSet.draft: [
+          titleRequired, /*atLeastOneTask*/
+        ],
+        StudyFormValidationSet.publish: [
+          titleRequired, /*atLeastOneTask*/
+        ],
+        StudyFormValidationSet.test: [
+          titleRequired, /*atLeastOneTask*/
+        ],
       };
 
   FormControlValidation get titleRequired => FormControlValidation(


### PR DESCRIPTION
This pull request fixes the issue of the validation banner appearing when the user navigates to the test screen without any defined intervention tasks for the study.

![image](https://github.com/user-attachments/assets/26f5b84c-41ba-4b34-b03f-fcd90124c56b)
