### PR TITLE
fix: auto-save new study

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_controller.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_controller.dart
@@ -88,7 +88,9 @@ class DashboardController extends _$DashboardController
   }
 
   void onClickNewStudy() {
-    router.dispatch(RoutingIntents.studyNew);
+    final Study newStudy = studyRepository.delegate.createNewInstance();
+    newStudy.save();
+    router.dispatch(RoutingIntents.studyEdit(newStudy.id));
   }
 
   Future<void> pinStudy(String modelId) async {

--- a/designer_v2/lib/features/dashboard/dashboard_controller.g.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_controller.g.dart
@@ -7,7 +7,7 @@ part of 'dashboard_controller.dart';
 // **************************************************************************
 
 String _$dashboardControllerHash() =>
-    r'2310b394163e63741253dd431a9131917a4a0853';
+    r'9fcff21f19bee7e50f7206ac8328a01ce921f775';
 
 /// See also [DashboardController].
 @ProviderFor(DashboardController)


### PR DESCRIPTION
This PR addresses an issue where creating a new study, opening the intervention screen, and closing it without making any changes would cause an exception. To prevent this, the study is now automatically saved immediately after clicking the "New Study" button.

To test this PR:
1. Create a new study by clicking the "New Study" button.
2. Open the intervention screen.
3. Close the intervention screen without making any changes.
4. Verify that no exception is thrown and the application continues to function as expected.