### PR TITLE
fix: hotfix to sanitize export contents

### DIFF
--- a/designer_v2/lib/features/analyze/study_export_zip.dart
+++ b/designer_v2/lib/features/analyze/study_export_zip.dart
@@ -21,7 +21,11 @@ extension StudyExportZipX on StudyExportData {
     };
 
     files.forEach((filename, content) {
-      final archiveFile = ArchiveFile.string(filename, content);
+      final archiveFile = ArchiveFile.string(
+        filename,
+        // todo sanitize contents manually until archive v4 is released
+        content.replaceAll('’', "'").replaceAll('…', '...'),
+      );
       archive.addFile(archiveFile);
     });
 

--- a/designer_v2/lib/utils/file_download.dart
+++ b/designer_v2/lib/utils/file_download.dart
@@ -16,7 +16,7 @@ dynamic downloadFile({required String fileContent, required String filename}) {
 void downloadBytes({required List<int> bytes, required String filename}) {
   if (!kIsWeb) {
     throw Exception(
-      "The StudyU designer only support the web platform".hardcoded,
+      "The StudyU Designer only support the web platform".hardcoded,
     );
   }
   final content = base64Encode(bytes);


### PR DESCRIPTION
Export archive seems to have issues with proper utf-8 encoding for zip files. I have replaced the problematic symbols manually for now. Let's wait for archive package v4 to be released before looking into this further.