### PR TITLE
fix: current intervention text split

### DIFF
--- a/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
@@ -87,14 +87,17 @@ class _TaskOverviewState extends State<TaskOverview> {
             children: [
               const SizedBox(height: 16),
               Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Expanded(
+                  Flexible(
                     child: Text(
                       AppLocalizations.of(context)!.intervention_current,
                       style: theme.textTheme.titleLarge,
                     ),
                   ),
-                  const Spacer(),
+                  const SizedBox(
+                    width: 5,
+                  ),
                   Text(
                     '${widget.subject!.daysLeftForPhase(widget.subject!.getInterventionIndexForDate(DateTime.now()))} ${AppLocalizations.of(context)!.days_left}',
                     style: const TextStyle(color: primaryColor),

--- a/app/lib/screens/study/report/performance/performance_section.dart
+++ b/app/lib/screens/study/report/performance/performance_section.dart
@@ -157,7 +157,7 @@ class PerformanceBar extends StatelessWidget {
             .map<Color>((index) => rainbow[index])
             .toList();
 
-    final spacing = (minimum! * 1000).floor();
+    //final spacing = (minimum! * 1000).floor();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/screens/study/report/performance/performance_section.dart
+++ b/app/lib/screens/study/report/performance/performance_section.dart
@@ -203,7 +203,9 @@ class PerformanceBar extends StatelessWidget {
             ),
           ),
         ),
-        if (minimum != null && minimum! >= 0 && minimum! <= 1)
+
+        /// Removing the minimum indicator since it is discussed as confusing in the meeting
+        /*if (minimum != null && minimum! >= 0 && minimum! <= 1)
           Column(
             children: [
               Row(
@@ -237,7 +239,7 @@ class PerformanceBar extends StatelessWidget {
                 ],
               ),
             ],
-          ),
+          ),*/
       ],
     );
   }

--- a/app/lib/screens/study/report/sections/average_section_widget.dart
+++ b/app/lib/screens/study/report/sections/average_section_widget.dart
@@ -77,8 +77,8 @@ class AverageSectionWidget extends ReportSectionWidget {
   BarChartData getChartData(BuildContext context, List<DiagramDatum> data) {
     final barGroups = getBarGroups(context, data);
     final maxY =
-        ((data.sortedBy((entry) => entry.value).toList().lastOrNull?.value ??
-                0))
+        (data.sortedBy((entry) => entry.value).toList().lastOrNull?.value ??
+                0)
             .ceilToDouble();
     return BarChartData(
       titlesData: FlTitlesData(
@@ -94,11 +94,11 @@ class AverageSectionWidget extends ReportSectionWidget {
                         Tooltip(
                           message:
                               "One phase represents ${subject.study.schedule.phaseDuration} days",
-                          child: Icon(
+                          child: const Icon(
                             Icons.info,
                             size: 18,
                           ),
-                        )
+                        ),
                       ],
                     )
                   : const Text(""),

--- a/app/lib/screens/study/report/sections/average_section_widget.dart
+++ b/app/lib/screens/study/report/sections/average_section_widget.dart
@@ -78,17 +78,32 @@ class AverageSectionWidget extends ReportSectionWidget {
     final barGroups = getBarGroups(context, data);
     final maxY =
         ((data.sortedBy((entry) => entry.value).toList().lastOrNull?.value ??
-                    0) *
-                1.1)
+                0))
             .ceilToDouble();
     return BarChartData(
       titlesData: FlTitlesData(
         bottomTitles: AxisTitles(
           axisNameWidget:
               (section.aggregate != TemporalAggregation.intervention)
-                  ? const Text("Phase")
+                  ? Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        const Text("Phase"),
+                        const SizedBox(width: 8),
+                        Tooltip(
+                          message:
+                              "One phase represents ${subject.study.schedule.phaseDuration} days",
+                          child: Icon(
+                            Icons.info,
+                            size: 18,
+                          ),
+                        )
+                      ],
+                    )
                   : const Text(""),
           sideTitles: SideTitles(
+            reservedSize: 30,
             showTitles: true,
             getTitlesWidget: getTitles,
           ),


### PR DESCRIPTION
The text in the "Current Intervention" field on the dashboard screen was not splitting correctly on smaller screen sizes. This PR resolves the issue.

**Before the fix:**
```
Current Inter
vention
```

**After the fix:**
```
Current
Intervention
```