### PR TITLE
fix: current intervention text split

### DIFF
--- a/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
@@ -87,14 +87,17 @@ class _TaskOverviewState extends State<TaskOverview> {
             children: [
               const SizedBox(height: 16),
               Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Expanded(
+                  Flexible(
                     child: Text(
                       AppLocalizations.of(context)!.intervention_current,
                       style: theme.textTheme.titleLarge,
                     ),
                   ),
-                  const Spacer(),
+                  const SizedBox(
+                    width: 5,
+                  ),
                   Text(
                     '${widget.subject!.daysLeftForPhase(widget.subject!.getInterventionIndexForDate(DateTime.now()))} ${AppLocalizations.of(context)!.days_left}',
                     style: const TextStyle(color: primaryColor),


### PR DESCRIPTION
The text in the "Current Intervention" field on the dashboard screen was not splitting correctly on smaller screen sizes. This PR resolves the issue.

**Before the fix:**
```
Current Inter
vention
```

**After the fix:**
```
Current
Intervention
```