### PR TITLE
fix: Change choice IDs

### DIFF
--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -221,9 +221,13 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   late final FormArray<String> choiceResponseOptionsArray = FormArray(
     [for (int i = 0; i < customOptionsInitial; i++) FormControl(value: "")],
   );
+  final List<String> _choiceIds = [];
+  final Map<String, String> _choiceTextToIdMap = {};
   final int customOptionsMin = 2;
   final int customOptionsMax = 10;
   final int customOptionsInitial = 2;
+
+  List<String> get choiceIds => _choiceIds;
 
   FormArray get answerOptionsArray => {
         SurveyQuestionType.bool: boolResponseOptionsArray,
@@ -652,6 +656,16 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
       case SurveyQuestionType.choice:
         isMultipleChoiceControl.value =
             (data as ChoiceQuestionFormData).isMultipleChoice;
+        _choiceIds.clear();
+        _choiceIds.addAll(data.choiceIds);
+
+        _choiceTextToIdMap.clear();
+        final options = data.answerOptions;
+        final ids = data.choiceIds;
+        for (int i = 0; i < options.length && i < ids.length; i++) {
+          _choiceTextToIdMap[options[i]] = ids[i];
+        }
+
         // Unfortunately needed because of how [FormArray.updateValue] is implemented
         // Note: `formArray.value = []` does not remove any controls!
         answerOptionsArray.clear();
@@ -698,17 +712,50 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
           conditional: questionConditionalControl.value,
         );
       case SurveyQuestionType.choice:
+        final validOptions = validAnswerOptions;
+        final List<String> orderedIds = [];
+
+        final Map<String, List<String>> textToIdsMap = {};
+
+        for (int i = 0; i < validOptions.length; i++) {
+          final option = validOptions[i];
+          if (!textToIdsMap.containsKey(option)) {
+            textToIdsMap[option] = [];
+          }
+
+          if (i < _choiceIds.length) {
+            textToIdsMap[option]!.add(_choiceIds[i]);
+          } else {
+            textToIdsMap[option]!.add(const Uuid().v4());
+          }
+        }
+
+        for (final option in validOptions) {
+          if (textToIdsMap[option]!.isNotEmpty) {
+            orderedIds.add(textToIdsMap[option]!.removeAt(0));
+          } else {
+            orderedIds.add(const Uuid().v4());
+          }
+        }
+
+        _choiceIds.clear();
+        _choiceIds.addAll(orderedIds);
+
+        _choiceTextToIdMap.clear();
+        for (int i = 0; i < validOptions.length; i++) {
+          final key = "${validOptions[i]}_$i";
+          _choiceTextToIdMap[key] = orderedIds[i];
+        }
+
         return ChoiceQuestionFormData(
           questionId: questionId,
-          questionText: questionTextControl.value!,
-          // required
-          questionType: questionTypeControl.value!,
-          // required
+          questionText: questionTextControl.value!, // required
+          questionType: questionTypeControl.value!, // required
           questionInfoText: questionInfoTextControl.value,
           conditional: questionConditionalControl.value,
-          isMultipleChoice: isMultipleChoiceControl.value!,
-          // required
-          answerOptions: validAnswerOptions,
+          isMultipleChoice: isMultipleChoiceControl.value!, // required
+          answerOptions: validOptions,
+          choiceIds: orderedIds,
         );
       case SurveyQuestionType.scale:
         return ScaleQuestionFormData(
@@ -798,6 +845,10 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   @override
   void onNewItem() {
     answerOptionsArray.add(FormControl<String>());
+
+    if (questionType == SurveyQuestionType.choice) {
+      _choiceIds.add(const Uuid().v4());
+    }
   }
 
   @override

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
@@ -170,10 +170,12 @@ class ChoiceQuestionFormData extends QuestionFormData {
     super.conditional,
     this.isMultipleChoice = false,
     required this.answerOptions,
+    required this.choiceIds,
   });
 
   final bool isMultipleChoice;
   final List<String> answerOptions;
+  final List<String> choiceIds;
 
   @override
   List<String> get responseOptions => answerOptions;
@@ -189,6 +191,7 @@ class ChoiceQuestionFormData extends QuestionFormData {
       questionInfoText: question.rationale ?? '',
       isMultipleChoice: question.multiple,
       answerOptions: question.choices.map((choice) => choice.text).toList(),
+      choiceIds: question.choices.map((choice) => choice.id).toList(),
       conditional: question.conditional,
     );
     data.setResponseOptionsValidityFrom(eligibilityCriteria);
@@ -202,7 +205,11 @@ class ChoiceQuestionFormData extends QuestionFormData {
     question.prompt = questionText;
     question.rationale = questionInfoText;
     question.multiple = isMultipleChoice;
-    question.choices = answerOptions.map(_buildChoiceForValue).toList();
+    question.choices = List.generate(answerOptions.length, (index) {
+      final choice = Choice(choiceIds[index]);
+      choice.text = answerOptions[index];
+      return choice;
+    });
     question.conditional = conditional == null
         ? null
         : QuestionConditional<List<String>>.withCondition(
@@ -222,15 +229,15 @@ class ChoiceQuestionFormData extends QuestionFormData {
       questionInfoText: questionInfoText,
       isMultipleChoice: isMultipleChoice,
       answerOptions: [...answerOptions],
+      choiceIds: [...choiceIds],
       conditional: conditional?.deepCopy(),
     );
     data.responseOptionsValidity = responseOptionsValidity;
     return data;
   }
 
-  Choice _buildChoiceForValue(String value) {
-    final choiceId = const Uuid().v4();
-    final choice = Choice(choiceId);
+  Choice _buildChoiceForValue(String value, int index) {
+    final choice = Choice(choiceIds[index]);
     choice.text = value;
     return choice;
   }
@@ -238,7 +245,13 @@ class ChoiceQuestionFormData extends QuestionFormData {
   @override
   Answer constructAnswerFor(dynamic responseOption) {
     final question = toQuestion() as ChoiceQuestion;
-    final choice = _buildChoiceForValue(responseOption as String);
+    final index = answerOptions.indexOf(responseOption as String);
+    if (index == -1) {
+      final choice = Choice.withId();
+      choice.text = responseOption;
+      return question.constructAnswer([choice]);
+    }
+    final choice = _buildChoiceForValue(responseOption, index);
     return question.constructAnswer([choice]);
   }
 }


### PR DESCRIPTION
## Problem Description

Currently, the id of choices depends on the text. For future work and to align with our other ID structure, we want to switch to UUIDs that are assigned once at the creation of the choice and then stay permanent until the respective choice or the question is deleted (otherwise the conditional PR will have problems linking to a specific choice).

- [x] New choices should get a UUID instead of their text as id
- [x] Choice id's should not change

Follow up todo:
- [ ] Allow reordering of multiple choice items

### Important:
- [x] On reorder, ids should stick to their item and not their position
- [x] Old text IDs should be valid as well, we do not want to change them for compatibility reasons. UUIDs should only be given out to new choice creations.

## Example

```
 {
    "id": "afeac253-4bfe-47fe-9384-4236ded1bd50",
    "type": "choice",
    "prompt": "Does any of the following apply to you and has not been examined by a doctor yet?",
    "choices": [
      {
        "id": "start_of_symptoms_after_spinal_surgery", <--- CHANGE THIS to UUID
        "text": "Start of symptoms after spinal surgery"
      },
      {
        "id": "start_of_symptoms_after_diagnosis_of_cancer",
        "text": "Start of symptoms after diagnosis of cancer"
      },
      {
        "id": "unexpected_significant_weight_loss",
        "text": "Unexpected significant weight loss"
      },
      {
        "id": "start_of_symptoms_after_trauma",
        "text": "Start of symptoms after trauma"
      },
      {
        "id": "accompanying_numbness_of_your_legs",
        "text": "Accompanying numbness of your legs"
      }
    ],
    "multiple": true,
  },
```