### PR TITLE
fix(app): Improve loading screen error handling

### DIFF
--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3,7 +3,7 @@
 
   "loading": "Laden",
   "loading_error_title": "Ladefehler",
-  "loading_error_description": "Die Studiendaten konnten nicht abgerufen werden. Bitte überprüfen Sie Ihre Internetverbindung oder versuchen Sie es später erneut. Wenn das Problem weiterhin besteht, können Sie alle Daten löschen, um die App zurückzusetzen. Dadurch werden alle Ihre Studiendaten gelöscht und Sie müssen der Studie erneut beitreten.",
+  "loading_error_description": "Die Studiendaten konnten nicht abgerufen werden. Wenn Sie aktuell an einer Studie teilnehmen, wenden Sie sich bitte zuerst an Ihre Studienleitung. Kontaktieren Sie den Support nur, wenn Sie nicht an einer Studie teilnehmen oder Ihre Studienleitung Sie dazu auffordert. Löschen Sie Ihre Daten nur, wenn Sie von der Studienleitung oder dem Support dazu aufgefordert werden. Das Löschen entfernt alle Ihre Studiendaten und Sie müssen der Studie erneut beitreten.",
   "try_again": "Erneut versuchen",
   "delete_all_data": "Alle Daten löschen",
   "delete_all_data_description": "Möchten Sie wirklich alle Daten löschen? Dadurch werden alle Ihre Studiendaten gelöscht und Sie müssen der Studie erneut beitreten.",
@@ -297,5 +297,5 @@
   "maximum": "Maximum",
 
   "support_email_sent": "Support-E-Mail geöffnet",
-  "support_email_sent_description": "Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort. Wenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis."
+  "support_email_sent_description": "Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort.\n\nWenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -93,6 +93,16 @@
   "help": "Hilfe",
   "about": "Über StudyU",
   "contact": "Kontakt",
+  "contact_support": "Support kontaktieren",
+  "support_email_body": "Hallo,\n\nich habe einen Ladefehler in der StudyU App. Meine Subject-ID ist: {subjectId}\n\nBitte helfen Sie mir bei diesem Problem.\n\nVielen Dank.",
+  "@support_email_body": {
+    "description": "Text für Support-E-Mail, enthält die Subject-ID",
+    "placeholders": {
+      "subjectId": {
+        "type": "String"
+      }
+    }
+  },
   "settings": "Einstellungen",
 
   "survey": "Umfrage",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -294,5 +294,8 @@
   "missing_recordings": "Fehlende Aufzeichnungen",
   "average": "Durchschnitt",
   "minimum": "Minimum",
-  "maximum": "Maximum"
+  "maximum": "Maximum",
+
+  "support_email_sent": "Support-E-Mail geöffnet",
+  "support_email_sent_description": "Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort. Wenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -3,7 +3,7 @@
 
   "loading": "Loading",
   "loading_error_title": "Loading Error",
-  "loading_error_description": "The study data could not be retrieved. Please check your internet connection or try again later. If the problem persists, you can delete all data to reset the app. This will delete all your study data and you will have to rejoin the study.",
+  "loading_error_description": "The study data could not be retrieved. If you are currently participating in a study, please first contact your study supervisor for assistance. Only contact support if you are not in a study or your supervisor instructs you to do so. Do not delete your data unless told by your supervisor or support. Deleting data will remove all your study data and you will have to rejoin the study.",
   "try_again": "Try again",
   "delete_all_data": "Delete all data",
   "delete_all_data_description": "Do you really want to delete all data? This will delete all your study data and you will have to rejoin the study.",
@@ -292,5 +292,5 @@
   "minimum": "Minimum",
   "maximum": "Maximum",
   "support_email_sent": "Support Email Sent",
-  "support_email_sent_description": "Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding."
+  "support_email_sent_description": "Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply.\n\nIf you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -290,5 +290,7 @@
   "missing_recordings": "Missing recordings",
   "average": "Average",
   "minimum": "Minimum",
-    "maximum": "Maximum"
+  "maximum": "Maximum",
+  "support_email_sent": "Support Email Sent",
+  "support_email_sent_description": "Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -91,6 +91,16 @@
   "profile": "Profile",
   "help": "Help",
   "contact": "Contact",
+  "contact_support": "Contact Support",
+  "support_email_body": "Hello,\n\nI am experiencing a loading error in the StudyU app. My subject ID is: {subjectId}\n\nPlease assist me with this issue.\n\nThank you.",
+  "@support_email_body": {
+    "description": "Body of the support email, includes the subject ID",
+    "placeholders": {
+      "subjectId": {
+        "type": "String"
+      }
+    }
+  },
   "about": "About",
   "settings": "Settings",
   "yes": "yes",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -113,7 +113,7 @@ abstract class AppLocalizations {
   /// No description provided for @loading_error_description.
   ///
   /// In en, this message translates to:
-  /// **'The study data could not be retrieved. Please check your internet connection or try again later. If the problem persists, you can delete all data to reset the app. This will delete all your study data and you will have to rejoin the study.'**
+  /// **'The study data could not be retrieved. If you are currently participating in a study, please first contact your study supervisor for assistance. Only contact support if you are not in a study or your supervisor instructs you to do so. Do not delete your data unless told by your supervisor or support. Deleting data will remove all your study data and you will have to rejoin the study.'**
   String get loading_error_description;
 
   /// No description provided for @try_again.
@@ -1439,7 +1439,7 @@ abstract class AppLocalizations {
   /// No description provided for @support_email_sent_description.
   ///
   /// In en, this message translates to:
-  /// **'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.'**
+  /// **'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply.\n\nIf you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.'**
   String get support_email_sent_description;
 }
 

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1429,6 +1429,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Maximum'**
   String get maximum;
+
+  /// No description provided for @support_email_sent.
+  ///
+  /// In en, this message translates to:
+  /// **'Support Email Sent'**
+  String get support_email_sent;
+
+  /// No description provided for @support_email_sent_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.'**
+  String get support_email_sent_description;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -572,6 +572,18 @@ abstract class AppLocalizations {
   /// **'Contact'**
   String get contact;
 
+  /// No description provided for @contact_support.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact Support'**
+  String get contact_support;
+
+  /// Body of the support email, includes the subject ID
+  ///
+  /// In en, this message translates to:
+  /// **'Hello,\n\nI am experiencing a loading error in the StudyU app. My subject ID is: {subjectId}\n\nPlease assist me with this issue.\n\nThank you.'**
+  String support_email_body(String subjectId);
+
   /// No description provided for @about.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -276,6 +276,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get contact => 'Kontakt';
 
   @override
+  String get contact_support => 'Support kontaktieren';
+
+  @override
+  String support_email_body(String subjectId) {
+    return 'Hallo,\n\nich habe einen Ladefehler in der StudyU App. Meine Subject-ID ist: $subjectId\n\nBitte helfen Sie mir bei diesem Problem.\n\nVielen Dank.';
+  }
+
+  @override
   String get about => 'Über StudyU';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -740,4 +740,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get maximum => 'Maximum';
+
+  @override
+  String get support_email_sent => 'Support-E-Mail geöffnet';
+
+  @override
+  String get support_email_sent_description =>
+      'Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort. Wenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -16,7 +16,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get loading_error_description =>
-      'Die Studiendaten konnten nicht abgerufen werden. Bitte überprüfen Sie Ihre Internetverbindung oder versuchen Sie es später erneut. Wenn das Problem weiterhin besteht, können Sie alle Daten löschen, um die App zurückzusetzen. Dadurch werden alle Ihre Studiendaten gelöscht und Sie müssen der Studie erneut beitreten.';
+      'Die Studiendaten konnten nicht abgerufen werden. Wenn Sie aktuell an einer Studie teilnehmen, wenden Sie sich bitte zuerst an Ihre Studienleitung. Kontaktieren Sie den Support nur, wenn Sie nicht an einer Studie teilnehmen oder Ihre Studienleitung Sie dazu auffordert. Löschen Sie Ihre Daten nur, wenn Sie von der Studienleitung oder dem Support dazu aufgefordert werden. Das Löschen entfernt alle Ihre Studiendaten und Sie müssen der Studie erneut beitreten.';
 
   @override
   String get try_again => 'Erneut versuchen';
@@ -746,5 +746,5 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get support_email_sent_description =>
-      'Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort. Wenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis.';
+      'Ihre Support-Anfrage wurde in Ihrer E-Mail-App vorbereitet. Bitte senden Sie die E-Mail, um unser Support-Team zu erreichen und warten Sie auf eine Antwort.\n\nWenn Sie aktuell an einer Studie teilnehmen, dokumentieren Sie Ihre Ergebnisse bitte außerhalb der App, bis das Problem behoben ist. Vielen Dank für Ihr Verständnis.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -274,6 +274,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get contact => 'Contact';
 
   @override
+  String get contact_support => 'Contact Support';
+
+  @override
+  String support_email_body(String subjectId) {
+    return 'Hello,\n\nI am experiencing a loading error in the StudyU app. My subject ID is: $subjectId\n\nPlease assist me with this issue.\n\nThank you.';
+  }
+
+  @override
   String get about => 'About';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -16,7 +16,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get loading_error_description =>
-      'The study data could not be retrieved. Please check your internet connection or try again later. If the problem persists, you can delete all data to reset the app. This will delete all your study data and you will have to rejoin the study.';
+      'The study data could not be retrieved. If you are currently participating in a study, please first contact your study supervisor for assistance. Only contact support if you are not in a study or your supervisor instructs you to do so. Do not delete your data unless told by your supervisor or support. Deleting data will remove all your study data and you will have to rejoin the study.';
 
   @override
   String get try_again => 'Try again';
@@ -739,5 +739,5 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get support_email_sent_description =>
-      'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.';
+      'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply.\n\nIf you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -733,4 +733,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get maximum => 'Maximum';
+
+  @override
+  String get support_email_sent => 'Support Email Sent';
+
+  @override
+  String get support_email_sent_description =>
+      'Your support request has been prepared in your email app. Please send the email to reach our support team and wait for their reply. If you are currently participating in a study, please continue tracking your results outside the app until the issue is resolved. Thank you for your understanding.';
 }

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -8,6 +8,7 @@ import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/screens/app_onboarding/iframe_helper.dart';
 import 'package:studyu_app/screens/app_onboarding/preview.dart'
     as study_preview;
+import 'package:studyu_app/screens/study/dashboard/contact_tab/contact_screen.dart';
 import 'package:studyu_app/screens/study/onboarding/eligibility_screen.dart';
 import 'package:studyu_app/screens/study/tasks/task_screen.dart';
 import 'package:studyu_app/util/cache.dart';
@@ -56,10 +57,9 @@ class _LoadingScreenState extends State<LoadingScreen> {
       Navigator.pushReplacementNamed(context, Routes.dashboard);
     } else {
       StudyULogger.warning(
-        "No subject found for ID: $selectedSubjectId. Local data will be cleared.",
+        "No subject found for ID: $selectedSubjectId.",
       );
-      SecureStorage.deleteAll();
-      await noSubjectFound();
+      await _showSupportOrDeleteDialog();
     }
   }
 
@@ -113,77 +113,13 @@ class _LoadingScreenState extends State<LoadingScreen> {
           // app hangs and is unresponsive
           StudyULogger.fatal('Could not login and retrieve the study subject. '
               'One reason for this might be that the study subject is no '
-              'longer available and only resides in app backup');
+              'longer available and only resides in app backup, or the study '
+              'subject is corrupted.');
           // throw Exception("Remote subject not found");
           // Ask the user if they want to delete all secure storage data or try to re-read
           // show popup dialog to the user
-          if (!mounted) return null;
-          final result = await showDialog<bool>(
-            context: context,
-            barrierDismissible: false,
-            builder: (context) {
-              return AlertDialog(
-                title: Text(AppLocalizations.of(context)!.loading_error_title),
-                content: Text(
-                  AppLocalizations.of(context)!.loading_error_description,
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(false),
-                    child: Text(AppLocalizations.of(context)!.try_again),
-                  ),
-                  TextButton(
-                    style: TextButton.styleFrom(
-                      foregroundColor: Colors.red,
-                    ),
-                    onPressed: () => Navigator.of(context).pop(true),
-                    child: Text(AppLocalizations.of(context)!.delete_data),
-                  ),
-                ],
-              );
-            },
-          );
-          if (result == true) {
-            if (!mounted) return null;
-            // Confirm deletion of storage data
-            final deleteResult = await showDialog<bool>(
-              context: context,
-              barrierDismissible: false,
-              builder: (context) {
-                return AlertDialog(
-                  title: Text(AppLocalizations.of(context)!.delete_all_data),
-                  content: Text(AppLocalizations.of(context)!
-                      .delete_all_data_description),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: Text(AppLocalizations.of(context)!.cancel),
-                    ),
-                    TextButton(
-                      style: TextButton.styleFrom(
-                        foregroundColor: Colors.red,
-                      ),
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: Text(AppLocalizations.of(context)!.reset_app),
-                    ),
-                  ],
-                );
-              },
-            );
-            if (deleteResult == true) {
-              // Delete all secure storage data
-              StudyULogger.info("Deleting all secure storage data");
-              if (!mounted) return null;
-              await cancelNotifications(context);
-              await SecureStorage.deleteAll();
-              StudyULogger.info("Secure storage data deleted");
-            }
-          }
-          StudyULogger.info("User chose not to delete secure storage data. "
-              "Going back to loading screen");
-          if (mounted) {
-            Navigator.pushReplacementNamed(context, Routes.loading);
-          }
+          // if (!mounted) return null;
+          await _showSupportOrDeleteDialog();
         }
       }
     }
@@ -320,6 +256,106 @@ class _LoadingScreenState extends State<LoadingScreen> {
         return;
       }
     }
+  }
+
+  Future<void> _showSupportOrDeleteDialog() async {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(AppLocalizations.of(context)!.loading_error_title),
+          content: Text(
+            AppLocalizations.of(context)!.loading_error_description,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              // todo translate
+              child: const Text('Contact Support'),
+            ),
+            TextButton(
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.red,
+              ),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(AppLocalizations.of(context)!.delete_data),
+            ),
+          ],
+        );
+      },
+    );
+    if (result == true) {
+      if (!mounted) return;
+      // Confirm deletion of storage data
+      final deleteResult = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return AlertDialog(
+            title: Text(AppLocalizations.of(context)!.delete_all_data),
+            content:
+                Text(AppLocalizations.of(context)!.delete_all_data_description),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: Text(AppLocalizations.of(context)!.cancel),
+              ),
+              TextButton(
+                style: TextButton.styleFrom(
+                  foregroundColor: Colors.red,
+                ),
+                onPressed: () => Navigator.of(context).pop(true),
+                child: Text(AppLocalizations.of(context)!.reset_app),
+              ),
+            ],
+          );
+        },
+      );
+      if (deleteResult == true) {
+        // Delete all secure storage data
+        StudyULogger.info("Deleting all secure storage data");
+        if (!mounted) return null;
+        await cancelNotifications(context);
+        await SecureStorage.deleteAll();
+        StudyULogger.info("Secure storage data deleted");
+      }
+    }
+    StudyULogger.info("User chose not to delete secure storage data.");
+    // Try to reload the subject from cache
+    try {
+      // If we have a subject, we can continue
+      final subject = await Cache.loadSubject();
+      StudyULogger.info("Loaded subject from cache: $subject");
+    } catch (e) {
+      // todo can user delete their study subject accidentally by going to welcome screen from contact screen?
+      StudyULogger.warning(
+        "No subject found in cache, showing support screen",
+      );
+      _showSupportDialog();
+    }
+  }
+
+  void _showSupportDialog() {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(AppLocalizations.of(context)!.contact),
+          content: RetryFutureBuilder<Contact>(
+            tryFunction: AppConfig.getAppContact,
+            successBuilder:
+                (BuildContext context, Contact? appSupportContact) =>
+                    ContactWidget(
+              contact: appSupportContact,
+              title: AppLocalizations.of(context)!.app_support,
+              subtitle: AppLocalizations.of(context)!.app_support_text,
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+        );
+      },
+    );
   }
 
   @override

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -320,15 +320,24 @@ class _LoadingScreenState extends State<LoadingScreen> {
     final emailBody = AppLocalizations.of(context)!
         .support_email_body(selectedSubjectId ?? '');
     final appContact = await AppConfig.getAppContact();
-    final emailUri = Uri(
-      scheme: 'mailto',
-      path: appContact.email,
-      queryParameters: {
-        'subject': emailSubject,
-        'body': emailBody,
+    final uriString =
+        'mailto:${appContact.email}?subject=${Uri.encodeComponent(emailSubject)}&body=${Uri.encodeComponent(emailBody)}';
+    final emailUri = Uri.parse(uriString);
+    await launchUrl(emailUri);
+
+    // Show non dismissible dialog to inform the user that support has been contacted
+    if (!mounted) return;
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(AppLocalizations.of(context)!.support_email_sent),
+          content: Text(
+              AppLocalizations.of(context)!.support_email_sent_description),
+        );
       },
     );
-    await launchUrl(emailUri);
   }
 
   @override

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -253,10 +253,16 @@ class _LoadingScreenState extends State<LoadingScreen> {
           title: Text(AppLocalizations.of(context)!.loading_error_title),
           content: Text(
             AppLocalizations.of(context)!.loading_error_description,
+            softWrap: true,
+            textAlign: TextAlign.start,
           ),
           actions: [
-            TextButton(
+            ElevatedButton(
               onPressed: () => Navigator.of(context).pop(false),
+              style: ElevatedButton.styleFrom(
+                foregroundColor: Colors.white,
+                backgroundColor: Theme.of(context).colorScheme.primary,
+              ),
               child: Text(AppLocalizations.of(context)!.contact_support),
             ),
             TextButton(

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
@@ -8,13 +6,13 @@ import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/screens/app_onboarding/iframe_helper.dart';
 import 'package:studyu_app/screens/app_onboarding/preview.dart'
     as study_preview;
-import 'package:studyu_app/screens/study/dashboard/contact_tab/contact_screen.dart';
 import 'package:studyu_app/screens/study/onboarding/eligibility_screen.dart';
 import 'package:studyu_app/screens/study/tasks/task_screen.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class LoadingScreen extends StatefulWidget {
   final String? sessionString;
@@ -59,7 +57,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       StudyULogger.warning(
         "No subject found for ID: $selectedSubjectId.",
       );
-      await _showSupportOrDeleteDialog();
+      await _showSupportOrDeleteDialog(selectedSubjectId);
     }
   }
 
@@ -99,27 +97,15 @@ class _LoadingScreenState extends State<LoadingScreen> {
         StudyULogger.warning(
           "Could not login and retrieve the study subject: $exception",
         );
-        if (exception is SocketException) {
-          subject = await Cache.loadSubject();
-          StudyULogger.info("Offline mode with cached subject: $subject");
-        } else {
-          // TODO further analyze this. How to recreate:
-          // 1. Participate in a study and wait some time until playstore uploads
-          // a backup of your current subject
-          // 2. Leave the study via the menu to delete all remote data
-          // 3. Uninstall the app and reinstall
-          // 4. Open the app but do not join a study
-          // 5. Restart the app. Either only this error shows up, worst case is
-          // app hangs and is unresponsive
-          StudyULogger.fatal('Could not login and retrieve the study subject. '
-              'One reason for this might be that the study subject is no '
-              'longer available and only resides in app backup, or the study '
-              'subject is corrupted.');
-          // throw Exception("Remote subject not found");
-          // Ask the user if they want to delete all secure storage data or try to re-read
-          // show popup dialog to the user
-          // if (!mounted) return null;
-          await _showSupportOrDeleteDialog();
+        StudyULogger.fatal('Could not login and retrieve the study subject.');
+        // Try to reload the subject from cache
+        try {
+          final subject = await Cache.loadSubject();
+          StudyULogger.info("Loaded subject from cache: $subject");
+        } catch (e) {
+          StudyULogger.warning(
+            "No subject found in cache",
+          );
         }
       }
     }
@@ -258,7 +244,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     }
   }
 
-  Future<void> _showSupportOrDeleteDialog() async {
+  Future<void> _showSupportOrDeleteDialog([String? selectedSubjectId]) async {
     final result = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
@@ -271,8 +257,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
-              // todo translate
-              child: const Text('Contact Support'),
+              child: Text(AppLocalizations.of(context)!.contact_support),
             ),
             TextButton(
               style: TextButton.styleFrom(
@@ -315,47 +300,35 @@ class _LoadingScreenState extends State<LoadingScreen> {
       if (deleteResult == true) {
         // Delete all secure storage data
         StudyULogger.info("Deleting all secure storage data");
-        if (!mounted) return null;
+        if (!mounted) return;
         await cancelNotifications(context);
         await SecureStorage.deleteAll();
         StudyULogger.info("Secure storage data deleted");
       }
     }
     StudyULogger.info("User chose not to delete secure storage data.");
-    // Try to reload the subject from cache
-    try {
-      // If we have a subject, we can continue
-      final subject = await Cache.loadSubject();
-      StudyULogger.info("Loaded subject from cache: $subject");
-    } catch (e) {
-      // todo can user delete their study subject accidentally by going to welcome screen from contact screen?
-      StudyULogger.warning(
-        "No subject found in cache, showing support screen",
-      );
-      _showSupportDialog();
-    }
+    if (!mounted) return;
+    await _contactSupport(selectedSubjectId);
   }
 
-  void _showSupportDialog() {
-    showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(AppLocalizations.of(context)!.contact),
-          content: RetryFutureBuilder<Contact>(
-            tryFunction: AppConfig.getAppContact,
-            successBuilder:
-                (BuildContext context, Contact? appSupportContact) =>
-                    ContactWidget(
-              contact: appSupportContact,
-              title: AppLocalizations.of(context)!.app_support,
-              subtitle: AppLocalizations.of(context)!.app_support_text,
-              color: Theme.of(context).primaryColor,
-            ),
-          ),
-        );
+  Future<void> _contactSupport([String? selectedSubjectId]) async {
+    if (!mounted) return;
+    StudyULogger.info(
+        "User chose to contact support with ID: $selectedSubjectId");
+
+    const emailSubject = 'StudyU Support Request - Loading Error';
+    final emailBody = AppLocalizations.of(context)!
+        .support_email_body(selectedSubjectId ?? '');
+    final appContact = await AppConfig.getAppContact();
+    final emailUri = Uri(
+      scheme: 'mailto',
+      path: appContact.email,
+      queryParameters: {
+        'subject': emailSubject,
+        'body': emailBody,
       },
     );
+    await launchUrl(emailUri);
   }
 
   @override

--- a/core/lib/src/models/tables/study.dart
+++ b/core/lib/src/models/tables/study.dart
@@ -251,6 +251,7 @@ class Study extends SupabaseObjectFunctions<Study>
           .neq('status', StudyStatus.closed.name);
       final extracted = SupabaseQuery.extractSupabaseList<Study>(
         List<Map<String, dynamic>>.from(response),
+        throwForNonExtracted: true,
       );
       result = ExtractionSuccess<Study>(extracted);
     } on ExtractionFailedException<Study> catch (error) {

--- a/core/lib/src/util/supabase_object.dart
+++ b/core/lib/src/util/supabase_object.dart
@@ -116,8 +116,9 @@ class SupabaseQuery {
   /// If some records could not be extracted, [ExtractionFailedException] is
   /// thrown containing the extracted records and the faulty records.
   static List<T> extractSupabaseList<T extends SupabaseObject>(
-    List<Map<String, dynamic>> response,
-  ) {
+    List<Map<String, dynamic>> response, {
+    bool throwForNonExtracted = false,
+  }) {
     final extracted = <T>[];
     final notExtracted = <JsonWithError>[];
     for (final json in response) {
@@ -131,9 +132,22 @@ class SupabaseQuery {
       }
     }
     if (notExtracted.isNotEmpty) {
-      // If some records could not be extracted, we throw an exception
-      // with the extracted records and the faulty records
-      throw ExtractionFailedException(extracted, notExtracted);
+      StudyULogger.warning(
+        'Some records could not be extracted: ${notExtracted.length} errors',
+      );
+      StudyULogger.debug(
+        'Not extracted records: ${notExtracted.map((e) => e.json).join(', ')}',
+      );
+      StudyUDiagnostics.captureException(
+        ExtractionFailedException(extracted, notExtracted),
+      );
+      // Only throw if we are supposed to throw for non-extracted records.
+      // Otherwise, we just log the error and return the extracted records.
+      if (throwForNonExtracted) {
+        // If some records could not be extracted, we throw an exception
+        // with the extracted records and the faulty records
+        throw ExtractionFailedException(extracted, notExtracted);
+      }
     }
     return extracted;
   }
@@ -186,6 +200,12 @@ class ExtractionFailedException<T> extends ExtractionResult<T>
   final List<JsonWithError> notExtracted;
 
   ExtractionFailedException(super.extracted, this.notExtracted);
+
+  @override
+  String toString() =>
+      'ExtractionFailedException: ${notExtracted.length} records failed to extract.\n'
+      'Extracted: $extracted\n'
+      'Not Extracted: ${notExtracted.map((e) => 'json: ${e.json}, error: ${e.error}').join('; ')}';
 }
 
 class JsonWithError {


### PR DESCRIPTION
## Problem

In case a json or some other error occurs on loading and the study subject cannot be retrieved, the app asks the user if they want to delete their data or try again. However, clicking try again still deletes the study data.

## Solution

This PR gives more guidance to the user on what to do when an error happens and the subject cannot be retrieved. It also offers the user to contact the administrator of the platform via email with their study subject id to get help from them. Deleting the data should only be the very last option.