### PR TITLE
fix: study duplication data loss

### DIFF
--- a/designer_v2/lib/features/app_drawer.dart
+++ b/designer_v2/lib/features/app_drawer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:studyu_designer_v2/assets.dart';
 import 'package:studyu_designer_v2/common_views/icons.dart';
 import 'package:studyu_designer_v2/features/account/account_settings.dart';
@@ -104,6 +105,9 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
   /// Flag to ensure router listener is only set up once
   bool _routerListenerSetUp = false;
 
+  /// Router reference for cleanup in dispose
+  GoRouter? _router;
+
   @override
   void initState() {
     super.initState();
@@ -170,10 +174,10 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
 
     // Set up router listener to detect route changes
     if (!_routerListenerSetUp) {
-      final router = ref.read(routerProvider);
+      _router = ref.read(routerProvider);
 
       // Listen to route information changes directly from the router
-      router.routeInformationProvider.addListener(_onRouteChanged);
+      _router!.routeInformationProvider.addListener(_onRouteChanged);
 
       _routerListenerSetUp = true;
     }
@@ -185,9 +189,8 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
   @override
   void dispose() {
     // Clean up the route listener
-    if (_routerListenerSetUp) {
-      final router = ref.read(routerProvider);
-      router.routeInformationProvider.removeListener(_onRouteChanged);
+    if (_routerListenerSetUp && _router != null) {
+      _router!.routeInformationProvider.removeListener(_onRouteChanged);
     }
     super.dispose();
   }

--- a/designer_v2/lib/features/app_drawer.dart
+++ b/designer_v2/lib/features/app_drawer.dart
@@ -20,6 +20,7 @@ class DrawerEntry {
     this.localizedHelpText,
     this.enabled = true,
   });
+
   final LocalizedStringResolver localizedTitle;
   final IconData? icon;
   final LocalizedStringResolver? localizedHelpText;
@@ -48,6 +49,7 @@ class GoRouterDrawerEntry extends DrawerEntry {
     required this.intent,
     this.onNavigated,
   });
+
   final RoutingIntent intent;
   final void Function()? onNavigated;
 
@@ -95,13 +97,18 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
   List<DrawerEntry> get allEntries =>
       [...topEntries, ...bottomEntries].expand((e) => e).toList();
 
-  /// Index of the currently selected [[NavigationGoRouterEntry]]
+  /// Index of the currently selected navigation entry
   /// Defaults to -1 if none of the entries is currently selected
   int _selectedIdx = -1;
+
+  /// Flag to ensure router listener is only set up once
+  bool _routerListenerSetUp = false;
 
   @override
   void initState() {
     super.initState();
+
+    // Initialize navigation entries
     topEntries = [
       [
         GoRouterDrawerEntry(
@@ -131,6 +138,7 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
         ),
       ],
     ];
+
     bottomEntries = [
       [
         DrawerEntry(
@@ -159,7 +167,38 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
+    // Set up router listener to detect route changes
+    if (!_routerListenerSetUp) {
+      final router = ref.read(routerProvider);
+
+      // Listen to route information changes directly from the router
+      router.routeInformationProvider.addListener(_onRouteChanged);
+
+      _routerListenerSetUp = true;
+    }
+
+    // Update the selected route when dependencies change
     _updateSelectedRoute();
+  }
+
+  @override
+  void dispose() {
+    // Clean up the route listener
+    if (_routerListenerSetUp) {
+      final router = ref.read(routerProvider);
+      router.routeInformationProvider.removeListener(_onRouteChanged);
+    }
+    super.dispose();
+  }
+
+  void _onRouteChanged() {
+    // Schedule update for next frame to ensure route change is complete
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _updateSelectedRoute();
+      }
+    });
   }
 
   void _updateSelectedRoute({int? hintEntryIdx}) {
@@ -169,19 +208,23 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
 
   int _getCurrentRouteIndex() {
     final currentRouteSettings = readCurrentRouteSettingsFrom(context);
+
     final idx = allEntries.indexWhere((e) {
       if (e is! GoRouterDrawerEntry) {
         return false;
       }
       return e.intent.matches(currentRouteSettings);
     });
+
     return idx;
   }
 
   void setSelectedIdx(int index) {
-    setState(() {
-      _selectedIdx = index;
-    });
+    if (_selectedIdx != index) {
+      setState(() {
+        _selectedIdx = index;
+      });
+    }
   }
 
   @override
@@ -222,8 +265,6 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
   }
 
   Widget _buildLogo(BuildContext context) {
-    // final textTheme = Theme.of(context).textTheme;
-
     return Container(
       constraints: BoxConstraints(
         minHeight: widget.logoSectionMinHeight,
@@ -272,7 +313,7 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
       widgets.add(const Divider(height: 1));
       widgets.add(const SizedBox(height: 8));
     }
-    // Slice off the last section divider
+    // Remove the last section divider
     return widgets.sublist(0, widgets.length - 3);
   }
 
@@ -309,7 +350,7 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
             ? theme.iconTheme.color!.withValues(alpha: 0.75)
             : theme.iconTheme.color!.withValues(alpha: 0.3),
       ),
-      //hoverColor: theme.colorScheme.primaryContainer.withOpacity(0.3),
+      // hoverColor: theme.colorScheme.primaryContainer.withOpacity(0.3),
       title: Text(
         entry.title,
         style: isSelected ? const TextStyle(fontWeight: FontWeight.bold) : null,

--- a/designer_v2/lib/repositories/api_client.dart
+++ b/designer_v2/lib/repositories/api_client.dart
@@ -14,7 +14,10 @@ abstract class StudyUApi {
 
   Future<Study> fetchStudy(StudyID studyId);
 
-  Future<List<Study>> getUserStudies();
+  Future<List<Study>> getUserStudies({
+    bool withParticipantActivity = false,
+    bool forDashboardDisplay = true,
+  });
 
   Future<void> deleteStudy(Study study);
 

--- a/designer_v2/lib/repositories/study_repository.dart
+++ b/designer_v2/lib/repositories/study_repository.dart
@@ -254,7 +254,7 @@ class StudyRepositoryDelegate extends IModelRepositoryDelegate<Study> {
 
   @override
   Future<List<Study>> fetchAll() {
-    return apiClient.getUserStudies();
+    return apiClient.getUserStudies(forDashboardDisplay: false);
   }
 
   @override

--- a/designer_v2/lib/repositories/study_repository.dart
+++ b/designer_v2/lib/repositories/study_repository.dart
@@ -111,12 +111,13 @@ class StudyRepository extends ModelRepository<Study>
   /// Since the Study object in the dashboard is fetched with limited columns (no intervention or measurement data),
   /// we need to fetch the full columns in order to duplicate it correctly.
   @override
-  Future<void> duplicateAndSave(Study model) async {
+  Future<Study> duplicateAndSave(Study model) async {
     final Study completeModel = await apiClient.fetchStudy(model.id);
     final duplicate = completeModel.duplicateAsDraft(
       authRepository.currentUser!.id,
     );
     await save(duplicate);
+    return duplicate;
   }
 
   @override
@@ -176,10 +177,10 @@ class StudyRepository extends ModelRepository<Study>
         type: StudyActionType.duplicateDraft,
         label: StudyActionType.duplicateDraft.string,
         onExecute: () async {
-          return await duplicateAndSave(model).then(
-            (value) =>
-                ref.read(routerProvider).dispatch(RoutingIntents.studies),
-          );
+          final duplicatedStudy = await duplicateAndSave(model);
+          return ref
+              .read(routerProvider)
+              .dispatch(RoutingIntents.studyEdit(duplicatedStudy.id));
         },
         isAvailable:
             model.status != StudyStatus.draft && model.canCopy(currentUser),
@@ -188,10 +189,10 @@ class StudyRepository extends ModelRepository<Study>
         type: StudyActionType.duplicate,
         label: StudyActionType.duplicate.string,
         onExecute: () async {
-          return await duplicateAndSave(model).then(
-            (value) =>
-                ref.read(routerProvider).dispatch(RoutingIntents.studies),
-          );
+          final duplicatedStudy = await duplicateAndSave(model);
+          return ref
+              .read(routerProvider)
+              .dispatch(RoutingIntents.studyEdit(duplicatedStudy.id));
         },
         isAvailable:
             model.status == StudyStatus.draft && model.canCopy(currentUser),


### PR DESCRIPTION
All data stored in lists (screening, consent, interventions, measurements, reports) is lost afterwards (not only visual but in database) and cannot be restored anymore.

Some additional finding: when copying a study as draft in the registry, the study list switches to my studies, but the sidebar does not reload

Steps to reproduce:

- Clone a study (from study registry or from my studies)
- Open the new study
- Go back to dashboard
- Open the new study again
- Perform a change in the study info section (maybe changing some other field would also work)
- All data in the list fields disappear and the broken study is pushed to server.

----

## Additional changes

- When duplicating a study, the study is directly opened.