### PR TITLE
feat(designer): dismissable barrier warnings

### DIFF
--- a/designer_v2/lib/common_views/form_buttons.dart
+++ b/designer_v2/lib/common_views/form_buttons.dart
@@ -60,9 +60,7 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
         return retainSizeInAppBar(
           DismissButton(
             key: const ValueKey('form_cancel_button'),
-            onPressed: () => formViewModel.cancel().then((_) {
-              if (context.mounted) Navigator.maybePop(context);
-            }),
+            onPressed: () => Navigator.maybePop(context),
           ),
         );
       },

--- a/designer_v2/lib/common_views/form_scaffold.dart
+++ b/designer_v2/lib/common_views/form_scaffold.dart
@@ -75,7 +75,10 @@ class _FormScaffoldState<T extends FormViewModel>
 
   Future<void> _promptBackNavigationConfirmation() async {
     if (!formViewModel.isDirty) {
-      Navigator.of(context).pop();
+      await formViewModel.cancel();
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
       return;
     }
     final shouldPop = await showDialog<bool>(

--- a/designer_v2/lib/common_views/sidesheet/sidesheet.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet.dart
@@ -248,6 +248,7 @@ Future<T?> showModalSideSheet<T extends Object?>({
   String? barrierLabel = "Sidesheet",
   bool useRootNavigator = true,
   RouteSettings? routeSettings,
+  Widget Function(Widget)? wrapRoute,
 }) {
   assert(!barrierDismissible || barrierLabel != null);
   return showGeneralDialog(
@@ -259,16 +260,19 @@ Future<T?> showModalSideSheet<T extends Object?>({
     useRootNavigator: useRootNavigator,
     routeSettings: routeSettings,
     context: context,
-    pageBuilder: (BuildContext context, _, _) => Sidesheet(
-      body: body,
-      tabs: tabs,
-      wrapContent: wrapContent,
-      width: width,
-      withCloseButton: withCloseButton,
-      ignoreAppBar: ignoreAppBar,
-      actionButtons: actionButtons,
-      titleText: title,
-    ),
+    pageBuilder: (BuildContext context, _, _) {
+      final sidesheet = Sidesheet(
+        body: body,
+        tabs: tabs,
+        wrapContent: wrapContent,
+        width: width,
+        withCloseButton: withCloseButton,
+        ignoreAppBar: ignoreAppBar,
+        actionButtons: actionButtons,
+        titleText: title,
+      );
+      return wrapRoute != null ? wrapRoute(sidesheet) : sidesheet;
+    },
     transitionBuilder: (_, animation, _, child) {
       return SlideTransition(
         position: Tween<Offset>(

--- a/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_designer_v2/common_views/form_buttons.dart';
@@ -5,6 +6,7 @@ import 'package:studyu_designer_v2/common_views/form_scaffold.dart';
 import 'package:studyu_designer_v2/common_views/navbar_tabbed.dart';
 import 'package:studyu_designer_v2/common_views/sidesheet/sidesheet.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model.dart';
+import 'package:studyu_designer_v2/features/forms/unsaved_changes_dialog.dart';
 import 'package:studyu_designer_v2/theme.dart';
 
 class FormSideSheetTab<T extends FormViewModel> extends NavbarTab {
@@ -20,6 +22,108 @@ class FormSideSheetTab<T extends FormViewModel> extends NavbarTab {
   FormViewBuilder<T> formViewBuilder;
 }
 
+class _FormSidesheetPopEntry<T extends FormViewModel> extends StatefulWidget {
+  const _FormSidesheetPopEntry({
+    required this.formViewModel,
+    required this.child,
+  });
+
+  final T formViewModel;
+  final Widget child;
+
+  @override
+  State<_FormSidesheetPopEntry<T>> createState() =>
+      _FormSidesheetPopEntryState<T>();
+}
+
+class _FormSidesheetPopEntryState<T extends FormViewModel>
+    extends State<_FormSidesheetPopEntry<T>>
+    implements PopEntry {
+  ModalRoute<dynamic>? _route;
+  final ValueNotifier<bool> _canPopNotifier = ValueNotifier(false);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _route?.unregisterPopEntry(this);
+    _route = ModalRoute.of(context);
+    debugPrint('[PopEntry] registering with route: ${_route.runtimeType}');
+    _route?.registerPopEntry(this);
+  }
+
+  @override
+  void dispose() {
+    _route?.unregisterPopEntry(this);
+    _route = null;
+    _canPopNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  ValueListenable<bool> get canPopNotifier => _canPopNotifier;
+
+  @override
+  void onPopInvokedWithResult(bool didPop, Object? result) {
+    debugPrint(
+      '[PopEntry] onPopInvokedWithResult didPop=$didPop canPop=${_canPopNotifier.value}',
+    );
+    if (didPop) {
+      return;
+    }
+    _handleDismiss();
+  }
+
+  @override
+  void onPopInvoked(bool didPop) {
+    // Deprecated
+  }
+
+  Future<void> _handleDismiss() async {
+    debugPrint(
+      '[PopEntry] _handleDismiss isDirty=${widget.formViewModel.isDirty}',
+    );
+
+    if (!widget.formViewModel.isDirty) {
+      await widget.formViewModel.cancel();
+      if (mounted) {
+        _canPopNotifier.value = true;
+
+        // CHANGE HERE: Wait for the frame to finish so Navigator is unlocked
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            Navigator.of(context, rootNavigator: true).pop();
+          }
+        });
+      }
+      return;
+    }
+
+    // Dirty state logic
+    final shouldDiscard = await showDialog<bool>(
+      context: context,
+      barrierColor: ThemeConfig.modalBarrierColor(Theme.of(context)),
+      builder: (context) => const UnsavedChangesDialog(),
+    );
+
+    if (shouldDiscard == true && mounted) {
+      await widget.formViewModel.cancel();
+      if (mounted && Navigator.of(context).canPop()) {
+        _canPopNotifier.value = true;
+
+        // CHANGE HERE: Wait for the frame to finish
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            Navigator.of(context, rootNavigator: true).pop();
+          }
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
 Future<Object?> showFormSideSheet<T extends FormViewModel>({
   required BuildContext context,
   required T formViewModel,
@@ -29,7 +133,7 @@ Future<Object?> showFormSideSheet<T extends FormViewModel>({
   double? width,
   bool withCloseButton = false,
   bool ignoreAppBar = true,
-  bool barrierDismissible = false,
+  bool barrierDismissible = true,
   Color? barrierColor,
 }) {
   barrierColor ??= ThemeConfig.modalBarrierColor(Theme.of(context));
@@ -65,5 +169,7 @@ Future<Object?> showFormSideSheet<T extends FormViewModel>({
     ignoreAppBar: ignoreAppBar,
     barrierDismissible: barrierDismissible,
     barrierColor: barrierColor,
+    wrapRoute: (sidesheet) =>
+        _FormSidesheetPopEntry(formViewModel: formViewModel, child: sidesheet),
   );
 }

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
@@ -321,14 +321,7 @@ class _MeasurementSurveyFormViewState
 
   List<Widget> _buildQuestionFormButtons(QuestionFormViewModel formViewModel) {
     return [
-      DismissButton(
-        onPressed: () {
-          final navigator = Navigator.of(context);
-          formViewModel.cancel().then((_) {
-            if (mounted) navigator.maybePop();
-          });
-        },
-      ),
+      const DismissButton(),
       ReactiveFormConsumer(
         builder: (context, form, child) {
           final fitbitCredentialsFormViewModel =

--- a/designer_v2/lib/features/forms/form_view_model.dart
+++ b/designer_v2/lib/features/forms/form_view_model.dart
@@ -65,12 +65,20 @@ abstract class FormViewModel<T> implements IFormGroupController {
     _restoreControlsFromFormData();
     _formModeUpdated();
     _applyValidationSet(validationSet);
+    Future.microtask(() {
+      finalizeInitializationBaseline();
+    });
 
     if (autosave) {
       // Push to event queue to avoid listening to update events
       // triggered synchronously during initialization
       runAsync(enableAutosave);
     }
+  }
+
+  void finalizeInitializationBaseline() {
+    prevFormValue = _getFullFormValue();
+    form.markAsPristine();
   }
 
   T? get formData => _formData;
@@ -133,17 +141,10 @@ abstract class FormViewModel<T> implements IFormGroupController {
   /// values are initialized in [setControlsFrom] (controls that are set
   /// programmatically are incorrectly marked as dirty without any user input).
   bool get isDirty {
-    _rememberDefaultControlStates();
+    if (prevFormValue == null) return false;
 
-    for (final control in form.controls.values) {
-      control.markAsEnabled(emitEvent: false, updateParent: false);
-    }
-    final isEqual = jsonEncode(prevFormValue) == jsonEncode(form.value);
-
-    for (final control in form.controls.values) {
-      control.markAsEnabled(emitEvent: false, updateParent: false);
-    }
-    _restoreControlStates(emitEvent: false, updateParent: false);
+    final currentFormValue = _getFullFormValue();
+    final isEqual = jsonEncode(prevFormValue) == jsonEncode(currentFormValue);
 
     return !isEqual;
   }
@@ -169,10 +170,29 @@ abstract class FormViewModel<T> implements IFormGroupController {
   void _setFormData(T? formData) {
     _formData = formData;
     if (formData != null) {
-      setControlsFrom(formData); // update [form] controls automatically
+      setControlsFrom(formData);
     }
-    prevFormValue = {...form.value};
-    form.updateValueAndValidity();
+    finalizeInitializationBaseline();
+  }
+
+  JsonMap _getFullFormValue() {
+    _rememberDefaultControlStates();
+
+    // 1. Temporarily enable all controls
+    for (final control in form.controls.values) {
+      control.markAsEnabled(emitEvent: false, updateParent: false);
+    }
+    // 2. CRITICAL: Force the FormGroup to rebuild its value cache!
+    form.updateValueAndValidity(updateParent: false, emitEvent: false);
+
+    // 3. Deep copy the full value
+    final fullValue = jsonDecode(jsonEncode(form.value)) as JsonMap;
+
+    // 4. Restore original states and rebuild the cache again
+    _restoreControlStates(emitEvent: false, updateParent: false);
+    form.updateValueAndValidity(updateParent: false, emitEvent: false);
+
+    return fullValue;
   }
 
   void _rememberDefaultControlStates() {

--- a/designer_v2/lib/features/recruit/invite_code_form_controller.dart
+++ b/designer_v2/lib/features/recruit/invite_code_form_controller.dart
@@ -170,9 +170,12 @@ class InviteCodeFormViewModel extends FormViewModel<StudyInvite> {
 
   @override
   Future<StudyInvite> save({bool updateState = true}) {
-    return inviteCodeRepository
-        .save(buildFormData())
-        .then((wrapped) => wrapped!.model);
+    return inviteCodeRepository.save(buildFormData()).then((wrapped) {
+      if (updateState) {
+        finalizeInitializationBaseline();
+      }
+      return wrapped!.model;
+    });
   }
 }
 

--- a/designer_v2/lib/features/recruit/invite_code_form_controller.dart
+++ b/designer_v2/lib/features/recruit/invite_code_form_controller.dart
@@ -117,6 +117,7 @@ class InviteCodeFormViewModel extends FormViewModel<StudyInvite> {
   @override
   void initControls() {
     regenerateCode(); // initialize randomly
+    prevFormValue = {...form.value};
   }
 
   // - Validation

--- a/designer_v2/test/common_views/form_scaffold_test.dart
+++ b/designer_v2/test/common_views/form_scaffold_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('clean FormScaffold cancellation notifies the form view model', () {
+    final source = File(
+      'lib/common_views/form_scaffold.dart',
+    ).readAsStringSync();
+    final cleanPopStart = source.indexOf('if (!formViewModel.isDirty)');
+    final cleanPopEnd = source.indexOf('return;', cleanPopStart);
+
+    expect(cleanPopStart, isNonNegative);
+    expect(cleanPopEnd, isNonNegative);
+
+    final cleanPopSource = source.substring(cleanPopStart, cleanPopEnd);
+
+    expect(
+      cleanPopSource,
+      contains('formViewModel.cancel()'),
+      reason:
+          'Default Cancel now enters FormScaffold through Navigator.maybePop(), '
+          'so the clean-pop branch must still notify the form view model before '
+          'closing.',
+    );
+  });
+}

--- a/designer_v2/test/features/design/measurements/survey/survey_form_view_test.dart
+++ b/designer_v2/test/features/design/measurements/survey/survey_form_view_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'survey question sidesheet Cancel asks before resetting dirty state',
+    () {
+      final source = File(
+        'lib/features/design/measurements/survey/survey_form_view.dart',
+      ).readAsStringSync();
+      final questionButtonsStart = source.indexOf(
+        'List<Widget> _buildQuestionFormButtons',
+      );
+      final questionButtonsEnd = source.indexOf(
+        'ReactiveFormConsumer',
+        questionButtonsStart,
+      );
+
+      expect(questionButtonsStart, isNonNegative);
+      expect(questionButtonsEnd, isNonNegative);
+
+      final questionCancelButtonSource = source.substring(
+        questionButtonsStart,
+        questionButtonsEnd,
+      );
+      final cancelIndex = questionCancelButtonSource.indexOf(
+        'formViewModel.cancel()',
+      );
+      final dismissButtonIndex = questionCancelButtonSource.indexOf(
+        'DismissButton',
+      );
+
+      expect(dismissButtonIndex, isNonNegative);
+      expect(
+        cancelIndex,
+        isNegative,
+        reason:
+            'Custom Cancel must let the sidesheet PopEntry call '
+            'formViewModel.cancel() after it checks dirty state and asks for '
+            'discard confirmation.',
+      );
+    },
+  );
+}

--- a/designer_v2/test/features/recruit/invite_code_form_controller_test.dart
+++ b/designer_v2/test/features/recruit/invite_code_form_controller_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('saving an invite code marks the form baseline as clean', () {
+    final source = File(
+      'lib/features/recruit/invite_code_form_controller.dart',
+    ).readAsStringSync();
+    final saveStart = source.indexOf('Future<StudyInvite> save');
+    final saveEnd = source.indexOf('\n  }', saveStart);
+
+    expect(saveStart, isNonNegative);
+    expect(saveEnd, isNonNegative);
+
+    final saveSource = source.substring(saveStart, saveEnd);
+
+    expect(
+      saveSource,
+      contains('finalizeInitializationBaseline'),
+      reason:
+          'InviteCodeFormViewModel.save() bypasses FormViewModel.save(), so it '
+          'must mark the current form values as clean before the sidesheet save '
+          'button asks Navigator.maybePop() to close.',
+    );
+  });
+}


### PR DESCRIPTION
This pull request introduces several improvements to the form handling and sidesheet modal logic, especially around unsaved changes and form dirty state detection. The changes enhance user experience by providing better prompts for unsaved changes, improving form state management, and making the modal sidesheet more flexible.

**Form Dirty State Handling and Modal Dismissal:**

* Improved dirty state detection in `FormViewModel` by introducing a more reliable way to compare the initial and current form state, using a new `_getFullFormValue()` method and a dedicated `finalizeInitializationBaseline()` function. This ensures that programmatic changes to the form do not incorrectly mark it as dirty. [[1]](diffhunk://#diff-8fde232d80fda3da175c7aebb12890a02d1a326d33f0c4b837ae7e85c0a4dc1fR68-R70) [[2]](diffhunk://#diff-8fde232d80fda3da175c7aebb12890a02d1a326d33f0c4b837ae7e85c0a4dc1fR79-R83) [[3]](diffhunk://#diff-8fde232d80fda3da175c7aebb12890a02d1a326d33f0c4b837ae7e85c0a4dc1fL136-R147) [[4]](diffhunk://#diff-8fde232d80fda3da175c7aebb12890a02d1a326d33f0c4b837ae7e85c0a4dc1fL172-R195)
* Added a new `_FormSidesheetPopEntry` widget and integrated it into the form sidesheet flow. This widget intercepts the modal pop action and, if the form is dirty, prompts the user with an `UnsavedChangesDialog`. If the user confirms, the form cancels and the modal is dismissed; otherwise, the modal remains open. [[1]](diffhunk://#diff-cfec67d98ec4a141fd705c3017a0bb1bd457d2f469fe7cfcaef140b3dd290597R1-R9) [[2]](diffhunk://#diff-cfec67d98ec4a141fd705c3017a0bb1bd457d2f469fe7cfcaef140b3dd290597R25-R126) [[3]](diffhunk://#diff-cfec67d98ec4a141fd705c3017a0bb1bd457d2f469fe7cfcaef140b3dd290597R172-R173)
* Changed the default for `barrierDismissible` in `showFormSideSheet` to `true`, allowing users to dismiss the modal by clicking outside it, but with proper handling of unsaved changes.

**Sidesheet Modal Enhancements:**

* Updated `showModalSideSheet` to accept a new `wrapRoute` parameter, allowing the modal content to be wrapped with custom widgets (such as `_FormSidesheetPopEntry` for pop interception). [[1]](diffhunk://#diff-69760659ea4ca8cb86a93bcf7e96efe4ed999de0ef69b401efb1105c0e58d576R251) [[2]](diffhunk://#diff-69760659ea4ca8cb86a93bcf7e96efe4ed999de0ef69b401efb1105c0e58d576L262-R264) [[3]](diffhunk://#diff-69760659ea4ca8cb86a93bcf7e96efe4ed999de0ef69b401efb1105c0e58d576L271-R275)

**Minor Improvements:**

* Simplified the `DismissButton` in `form_buttons.dart` to directly pop the navigation stack, removing unnecessary async logic.
* Updated the Supabase public anon key in the development environment configuration.
* Ensured `prevFormValue` is initialized in `InviteCodeFormViewModel` for correct dirty state tracking.