### PR TITLE
feat(designer): move fitbit credentials into measurement question editor

### DIFF
--- a/designer_v2/lib/constants.dart
+++ b/designer_v2/lib/constants.dart
@@ -34,7 +34,6 @@ const String studyEditInterventionRouteName = 'studyEditIntervention';
 const String studyEditMeasurementsRouteName = 'studyEditMeasurements';
 const String studyEditReportsRouteName = 'studyEditReports';
 const String studyEditMeasurementRouteName = 'studyEditMeasurement';
-const String studyEditFitbitCredentialsRouteName = 'studyEditFitbitCredentials';
 const String studyTestRouteName = 'studyTest';
 const String studyRecruitRouteName = 'studyRecruit';
 const String studyMonitorRouteName = 'studyMonitor';

--- a/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_controller.dart
+++ b/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_controller.dart
@@ -6,6 +6,7 @@ import 'package:studyu_designer_v2/features/design/study_form_validation.dart';
 import 'package:studyu_designer_v2/features/forms/form_validation.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model.dart';
 import 'package:studyu_designer_v2/features/study/study_controller.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/repositories/fitbit_credentials_repository.dart';
 
 part 'fitbit_credentials_form_controller.g.dart';
@@ -29,6 +30,7 @@ class FitbitCredentialsFormViewModel
 
   final FormControl<String> clientIdControl = FormControl();
   final FormControl<String> clientSecretControl = FormControl();
+  bool _questionValidationEnabled = false;
 
   @override
   void initControls() {
@@ -63,10 +65,40 @@ class FitbitCredentialsFormViewModel
 
   @override
   FormValidationConfigSet get sharedValidationConfig => {
-    StudyFormValidationSet.draft: [],
-    StudyFormValidationSet.publish: [fitbitCredentialsValidation],
-    StudyFormValidationSet.test: [],
+    StudyFormValidationSet.draft: _questionValidationEnabled
+        ? [clientIdRequired, clientSecretRequired]
+        : [],
+    StudyFormValidationSet.publish: [
+      if (_questionValidationEnabled) clientIdRequired,
+      if (_questionValidationEnabled) clientSecretRequired,
+      fitbitCredentialsValidation,
+    ],
+    StudyFormValidationSet.test: _questionValidationEnabled
+        ? [clientIdRequired, clientSecretRequired]
+        : [],
   };
+
+  FormControlValidation get clientIdRequired => FormControlValidation(
+    control: clientIdControl,
+    validators: [Validators.required],
+    validationMessages: {
+      ValidationMessage.required: (_) => tr.fitbit_client_id_required,
+    },
+  );
+
+  FormControlValidation get clientSecretRequired => FormControlValidation(
+    control: clientSecretControl,
+    validators: [Validators.required],
+    validationMessages: {
+      ValidationMessage.required: (_) => tr.fitbit_client_secret_required,
+    },
+  );
+
+  void enableQuestionValidation() {
+    _questionValidationEnabled = true;
+    revalidate();
+    form.updateValueAndValidity();
+  }
 
   FormControlValidation get fitbitCredentialsValidation =>
       FormControlValidation(
@@ -137,6 +169,7 @@ FitbitCredentialsFormViewModel fitbitCredentialsFormViewModel(
 
   return FitbitCredentialsFormViewModel(
     study: state.studyValueRequired,
+    validationSet: StudyFormValidationSet.draft,
     fitbitCredentialsRepository: fitbitCredentialsRepository,
   );
 }

--- a/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_controller.g.dart
+++ b/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_controller.g.dart
@@ -77,7 +77,7 @@ final class FitbitCredentialsFormViewModelProvider
 }
 
 String _$fitbitCredentialsFormViewModelHash() =>
-    r'48f5beab67898dea41cacd2ef9dfe297356e4a17';
+    r'dd4d4a74b099d59056da3a49b9d6554603f430ad';
 
 final class FitbitCredentialsFormViewModelFamily extends $Family
     with $FunctionalFamilyOverride<FitbitCredentialsFormViewModel, StudyID> {

--- a/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_view.dart
+++ b/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_view.dart
@@ -8,10 +8,7 @@ import 'package:studyu_designer_v2/localization/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class FitbitCredentialsSection extends StatelessWidget {
-  const FitbitCredentialsSection({
-    required this.formViewModel,
-    super.key,
-  });
+  const FitbitCredentialsSection({required this.formViewModel, super.key});
 
   final FitbitCredentialsFormViewModel formViewModel;
 
@@ -30,9 +27,8 @@ class FitbitCredentialsSection extends StatelessWidget {
         Collapsible(
           title: AppLocalizations.of(context)!.fitbit_credentials_how_to_obtain,
           maintainState: false,
-          contentBuilder: (context, isCollapsed) => FitbitCredentialsHelpContent(
-            onLaunchUrl: _launchURL,
-          ),
+          contentBuilder: (context, isCollapsed) =>
+              FitbitCredentialsHelpContent(onLaunchUrl: _launchURL),
         ),
         const SizedBox(height: 16.0),
         FormTableLayout(
@@ -51,8 +47,9 @@ class FitbitCredentialsSection extends StatelessWidget {
             FormTableRow(
               control: formViewModel.clientSecretControl,
               label: AppLocalizations.of(context)!.client_secret,
-              labelHelpText:
-                  AppLocalizations.of(context)!.client_secret_label_help,
+              labelHelpText: AppLocalizations.of(
+                context,
+              )!.client_secret_label_help,
               input: ReactiveTextField<String>(
                 formControl: formViewModel.clientSecretControl,
                 decoration: InputDecoration(
@@ -69,10 +66,7 @@ class FitbitCredentialsSection extends StatelessWidget {
 }
 
 class FitbitCredentialsHelpContent extends StatelessWidget {
-  const FitbitCredentialsHelpContent({
-    required this.onLaunchUrl,
-    super.key,
-  });
+  const FitbitCredentialsHelpContent({required this.onLaunchUrl, super.key});
 
   final Future<void> Function(String url) onLaunchUrl;
 
@@ -106,14 +100,21 @@ class FitbitCredentialsHelpContent extends StatelessWidget {
             ),
           ),
         ),
-        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step3),
-        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step4),
-        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step5),
-        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step6),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_step3,
+        ),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_step4,
+        ),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_step5,
+        ),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_step6,
+        ),
         InkWell(
-          onTap: () => onLaunchUrl(
-            'https://fitbit.google/enterprise/researchers-faqs/',
-          ),
+          onTap: () =>
+              onLaunchUrl('https://fitbit.google/enterprise/researchers-faqs/'),
           child: Text(
             AppLocalizations.of(context)!.fitbit_credentials_step7,
             style: TextStyle(
@@ -122,7 +123,9 @@ class FitbitCredentialsHelpContent extends StatelessWidget {
             ),
           ),
         ),
-        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step8),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_step8,
+        ),
         const SizedBox(height: 12.0),
         const FitbitCredentialsScreenshotsSection(),
         const SizedBox(height: 16.0),

--- a/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_view.dart
+++ b/designer_v2/lib/features/design/fitbit/fitbit_credentials_form_view.dart
@@ -1,161 +1,143 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reactive_forms/reactive_forms.dart';
-import 'package:studyu_designer_v2/common_views/async_value_widget.dart';
-import 'package:studyu_designer_v2/common_views/empty_body.dart';
+import 'package:studyu_designer_v2/common_views/collapse.dart';
 import 'package:studyu_designer_v2/common_views/form_table_layout.dart';
 import 'package:studyu_designer_v2/common_views/text_paragraph.dart';
 import 'package:studyu_designer_v2/features/design/fitbit/fitbit_credentials_form_controller.dart';
-import 'package:studyu_designer_v2/features/design/study_design_page_view.dart';
-import 'package:studyu_designer_v2/features/study/study_controller.dart';
 import 'package:studyu_designer_v2/localization/app_localizations.dart';
-import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class StudyDesignFitbitCredentialsFormView extends StudyDesignPageWidget {
-  const StudyDesignFitbitCredentialsFormView(super.studyId, {super.key});
+class FitbitCredentialsSection extends StatelessWidget {
+  const FitbitCredentialsSection({
+    required this.formViewModel,
+    super.key,
+  });
+
+  final FitbitCredentialsFormViewModel formViewModel;
 
   Future<void> _launchURL(String url) async {
-    final Uri uri = Uri.parse(url);
+    final uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(studyControllerProvider(studyId));
-
-    return AsyncValueWidget(
-      value: state.study,
-      data: (study) {
-        final formViewModel = ref.watch(
-          fitbitCredentialsFormViewModelProvider(studyId),
-        );
-
-        if (!study.isDraft) {
-          return Padding(
-            padding: const EdgeInsets.only(top: 24),
-            child: EmptyBody(
-              icon: Icons.block_sharp,
-              title: tr.fitbit_credentials_cannot_change_title,
-              description: tr.fitbit_credentials_cannot_change_description,
-            ),
-          );
-        }
-
-        return ReactiveForm(
-          formGroup: formViewModel.form,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              TextParagraph(
-                text: AppLocalizations.of(
-                  context,
-                )!.fitbit_credentials_instruction,
-              ),
-              const SizedBox(height: 12.0),
-              InkWell(
-                onTap: () => _launchURL('https://dev.fitbit.com/'),
-                child: Text(
-                  AppLocalizations.of(context)!.fitbit_credentials_step1,
-                  style: TextStyle(
-                    color: Theme.of(context).primaryColor,
-                    decoration: TextDecoration.underline,
-                  ),
-                ),
-              ),
-              InkWell(
-                onTap: () => _launchURL('https://accounts.fitbit.com/login'),
-                child: Text(
-                  AppLocalizations.of(context)!.fitbit_credentials_step2,
-                  style: TextStyle(
-                    color: Theme.of(context).primaryColor,
-                    decoration: TextDecoration.underline,
-                  ),
-                ),
-              ),
-              TextParagraph(
-                text: AppLocalizations.of(context)!.fitbit_credentials_step3,
-              ),
-              TextParagraph(
-                text: AppLocalizations.of(context)!.fitbit_credentials_step4,
-              ),
-              TextParagraph(
-                text: AppLocalizations.of(context)!.fitbit_credentials_step5,
-              ),
-              TextParagraph(
-                text: AppLocalizations.of(context)!.fitbit_credentials_step6,
-              ),
-              InkWell(
-                onTap: () => _launchURL(
-                  'https://fitbit.google/enterprise/researchers-faqs/',
-                ),
-                child: Text(
-                  AppLocalizations.of(context)!.fitbit_credentials_step7,
-                  style: TextStyle(
-                    color: Theme.of(context).primaryColor,
-                    decoration: TextDecoration.underline,
-                  ),
-                ),
-              ),
-              TextParagraph(
-                text: AppLocalizations.of(context)!.fitbit_credentials_step8,
-              ),
-              const SizedBox(height: 12.0),
-              _buildScreenshotsSection(context),
-              const SizedBox(height: 16.0),
-              _buildSingleParticipantInstructions(context),
-              const SizedBox(height: 24.0),
-              FormTableLayout(
-                rows: [
-                  FormTableRow(
-                    control: formViewModel.clientIdControl,
-                    label: AppLocalizations.of(context)!.client_id,
-                    labelHelpText: AppLocalizations.of(
-                      context,
-                    )!.client_id_label_help,
-                    input: Row(
-                      children: [
-                        Expanded(
-                          child: ReactiveTextField(
-                            formControl: formViewModel.clientIdControl,
-                            decoration: InputDecoration(
-                              hintText: AppLocalizations.of(
-                                context,
-                              )!.client_id_hint,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  FormTableRow(
-                    control: formViewModel.clientSecretControl,
-                    label: AppLocalizations.of(context)!.client_secret,
-                    labelHelpText: AppLocalizations.of(
-                      context,
-                    )!.client_secret_label_help,
-                    input: ReactiveTextField(
-                      formControl: formViewModel.clientSecretControl,
-                      decoration: InputDecoration(
-                        hintText: AppLocalizations.of(
-                          context,
-                        )!.client_secret_hint,
-                      ),
-                    ),
-                  ),
-                ],
-                columnWidths: const {0: FlexColumnWidth()},
-              ),
-            ],
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Collapsible(
+          title: AppLocalizations.of(context)!.fitbit_credentials_how_to_obtain,
+          maintainState: false,
+          contentBuilder: (context, isCollapsed) => FitbitCredentialsHelpContent(
+            onLaunchUrl: _launchURL,
           ),
-        );
-      },
+        ),
+        const SizedBox(height: 16.0),
+        FormTableLayout(
+          rows: [
+            FormTableRow(
+              control: formViewModel.clientIdControl,
+              label: AppLocalizations.of(context)!.client_id,
+              labelHelpText: AppLocalizations.of(context)!.client_id_label_help,
+              input: ReactiveTextField<String>(
+                formControl: formViewModel.clientIdControl,
+                decoration: InputDecoration(
+                  hintText: AppLocalizations.of(context)!.client_id_hint,
+                ),
+              ),
+            ),
+            FormTableRow(
+              control: formViewModel.clientSecretControl,
+              label: AppLocalizations.of(context)!.client_secret,
+              labelHelpText:
+                  AppLocalizations.of(context)!.client_secret_label_help,
+              input: ReactiveTextField<String>(
+                formControl: formViewModel.clientSecretControl,
+                decoration: InputDecoration(
+                  hintText: AppLocalizations.of(context)!.client_secret_hint,
+                ),
+              ),
+            ),
+          ],
+          columnWidths: const {0: FlexColumnWidth()},
+        ),
+      ],
     );
   }
+}
 
-  Widget _buildSingleParticipantInstructions(BuildContext context) {
+class FitbitCredentialsHelpContent extends StatelessWidget {
+  const FitbitCredentialsHelpContent({
+    required this.onLaunchUrl,
+    super.key,
+  });
+
+  final Future<void> Function(String url) onLaunchUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 12.0),
+        TextParagraph(
+          text: AppLocalizations.of(context)!.fitbit_credentials_instruction,
+        ),
+        const SizedBox(height: 12.0),
+        InkWell(
+          onTap: () => onLaunchUrl('https://dev.fitbit.com/'),
+          child: Text(
+            AppLocalizations.of(context)!.fitbit_credentials_step1,
+            style: TextStyle(
+              color: Theme.of(context).primaryColor,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+        InkWell(
+          onTap: () => onLaunchUrl('https://accounts.fitbit.com/login'),
+          child: Text(
+            AppLocalizations.of(context)!.fitbit_credentials_step2,
+            style: TextStyle(
+              color: Theme.of(context).primaryColor,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step3),
+        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step4),
+        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step5),
+        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step6),
+        InkWell(
+          onTap: () => onLaunchUrl(
+            'https://fitbit.google/enterprise/researchers-faqs/',
+          ),
+          child: Text(
+            AppLocalizations.of(context)!.fitbit_credentials_step7,
+            style: TextStyle(
+              color: Theme.of(context).primaryColor,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+        TextParagraph(text: AppLocalizations.of(context)!.fitbit_credentials_step8),
+        const SizedBox(height: 12.0),
+        const FitbitCredentialsScreenshotsSection(),
+        const SizedBox(height: 16.0),
+        const FitbitSingleParticipantInstructions(),
+        const SizedBox(height: 24.0),
+      ],
+    );
+  }
+}
+
+class FitbitSingleParticipantInstructions extends StatelessWidget {
+  const FitbitSingleParticipantInstructions({super.key});
+
+  @override
+  Widget build(BuildContext context) {
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 16.0),
       color: Theme.of(context).colorScheme.surfaceContainer,
@@ -200,26 +182,36 @@ class StudyDesignFitbitCredentialsFormView extends StudyDesignPageWidget {
       ),
     );
   }
+}
 
-  Widget _buildScreenshotsSection(BuildContext context) {
-    final ScrollController scrollController = ScrollController();
+class FitbitCredentialsScreenshotsSection extends StatefulWidget {
+  const FitbitCredentialsScreenshotsSection({super.key});
 
-    void scrollLeft() {
-      scrollController.animateTo(
-        scrollController.offset - 200.0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
+  @override
+  State<FitbitCredentialsScreenshotsSection> createState() =>
+      _FitbitCredentialsScreenshotsSectionState();
+}
 
-    void scrollRight() {
-      scrollController.animateTo(
-        scrollController.offset + 200.0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
+class _FitbitCredentialsScreenshotsSectionState
+    extends State<FitbitCredentialsScreenshotsSection> {
+  late final ScrollController scrollController = ScrollController();
 
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollBy(double amount) {
+    scrollController.animateTo(
+      scrollController.offset + amount,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -291,28 +283,18 @@ class StudyDesignFitbitCredentialsFormView extends StudyDesignPageWidget {
             ),
             Positioned(
               left: 0,
-              top: 0,
-              bottom: 0,
-              child: Container(
-                alignment: Alignment.center,
-                color: Colors.transparent,
-                child: IconButton(
-                  icon: const Icon(Icons.arrow_left, size: 32.0),
-                  onPressed: scrollLeft,
-                ),
+              top: 80,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_back_ios),
+                onPressed: () => _scrollBy(-200.0),
               ),
             ),
             Positioned(
               right: 0,
-              top: 0,
-              bottom: 0,
-              child: Container(
-                alignment: Alignment.center,
-                color: Colors.transparent,
-                child: IconButton(
-                  icon: const Icon(Icons.arrow_right, size: 32.0),
-                  onPressed: scrollRight,
-                ),
+              top: 80,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_forward_ios),
+                onPressed: () => _scrollBy(200.0),
               ),
             ),
           ],
@@ -323,56 +305,22 @@ class StudyDesignFitbitCredentialsFormView extends StudyDesignPageWidget {
 
   Widget _buildScreenshot(
     BuildContext context,
-    String imagePath,
+    String assetPath,
     String caption,
   ) {
-    return GestureDetector(
-      onTap: () => _showImageDialog(context, imagePath, caption),
-      child: Padding(
-        padding: const EdgeInsets.only(right: 12.0),
-        child: Column(
-          children: [
-            Expanded(
-              child: Image.asset(
-                imagePath,
-                fit: BoxFit.cover,
-                width: 200.0,
-                errorBuilder: (context, error, stackTrace) =>
-                    const Center(child: Icon(Icons.image_not_supported)),
-              ),
-            ),
-            const SizedBox(height: 8.0),
-            Text(caption, style: const TextStyle(fontSize: 12.0)),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showImageDialog(
-    BuildContext context,
-    String imagePath,
-    String caption,
-  ) {
-    showDialog(
-      context: context,
-      builder: (context) => Dialog(
-        backgroundColor: Colors.black87,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Image.asset(imagePath, fit: BoxFit.contain),
-            const SizedBox(height: 8.0),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                caption,
-                style: const TextStyle(fontSize: 14.0, color: Colors.white),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
-        ),
+    return Container(
+      width: 180.0,
+      margin: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Column(
+        children: [
+          Expanded(child: Image.asset(assetPath, fit: BoxFit.contain)),
+          const SizedBox(height: 8.0),
+          Text(
+            caption,
+            style: Theme.of(context).textTheme.bodySmall,
+            textAlign: TextAlign.center,
+          ),
+        ],
       ),
     );
   }

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
@@ -336,7 +336,8 @@ class _MeasurementSurveyFormViewState
           final requiresFitbitCredentials =
               formViewModel.questionType == SurveyQuestionType.fitbit;
 
-          if (!requiresFitbitCredentials || fitbitCredentialsFormViewModel == null) {
+          if (!requiresFitbitCredentials ||
+              fitbitCredentialsFormViewModel == null) {
             final validationSummary = formViewModel.form.validationErrorSummary
                 .trim();
             return PrimaryButton(
@@ -344,12 +345,14 @@ class _MeasurementSurveyFormViewState
               tooltipDisabled: _buildInvalidTooltip(validationSummary),
               icon: null,
               enabled: formViewModel.isValid,
-              onPressedFuture: formViewModel.isValid ? () {
-                final navigator = Navigator.of(context);
-                return formViewModel.save().then((_) {
-                  if (mounted) navigator.maybePop();
-                });
-              } : null,
+              onPressedFuture: formViewModel.isValid
+                  ? () {
+                      final navigator = Navigator.of(context);
+                      return formViewModel.save().then((_) {
+                        if (mounted) navigator.maybePop();
+                      });
+                    }
+                  : null,
             );
           }
 
@@ -361,7 +364,8 @@ class _MeasurementSurveyFormViewState
                   fitbitCredentialsFormViewModel.form.valid;
               final validationSummary = [
                 formViewModel.form.validationErrorSummary.trim(),
-                fitbitCredentialsFormViewModel.form.validationErrorSummary.trim(),
+                fitbitCredentialsFormViewModel.form.validationErrorSummary
+                    .trim(),
               ].where((summary) => summary.trim().isNotEmpty).join('\n\n');
 
               return PrimaryButton(
@@ -369,12 +373,14 @@ class _MeasurementSurveyFormViewState
                 tooltipDisabled: _buildInvalidTooltip(validationSummary),
                 icon: null,
                 enabled: isValid,
-                onPressedFuture: isValid ? () {
-                  final navigator = Navigator.of(context);
-                  return formViewModel.save().then((_) {
-                    if (mounted) navigator.maybePop();
-                  });
-                } : null,
+                onPressedFuture: isValid
+                    ? () {
+                        final navigator = Navigator.of(context);
+                        return formViewModel.save().then((_) {
+                          if (mounted) navigator.maybePop();
+                        });
+                      }
+                    : null,
               );
             },
           );

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_view.dart
@@ -3,7 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/common_views/form_buttons.dart';
 import 'package:studyu_designer_v2/common_views/form_table_layout.dart';
+import 'package:studyu_designer_v2/common_views/primary_button.dart';
 import 'package:studyu_designer_v2/common_views/sidesheet/sidesheet_form.dart';
 import 'package:studyu_designer_v2/common_views/styling_information.dart';
 import 'package:studyu_designer_v2/common_views/text_hyperlink.dart';
@@ -11,6 +13,7 @@ import 'package:studyu_designer_v2/features/design/measurements/survey/survey_fo
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_conditional_form_view.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_controller.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_view.dart';
+import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/question_type.dart';
 import 'package:studyu_designer_v2/features/design/shared/schedule/schedule_controls_view.dart';
 import 'package:studyu_designer_v2/features/design/study_form_providers.dart';
 import 'package:studyu_designer_v2/features/forms/form_list_view.dart';
@@ -294,6 +297,7 @@ class _MeasurementSurveyFormViewState
     showFormSideSheet<QuestionFormViewModel>(
       context: context,
       formViewModel: surveyQuestionFormViewModel,
+      actionButtons: _buildQuestionFormButtons(surveyQuestionFormViewModel),
       tabs: <FormSideSheetTab<QuestionFormViewModel>>[
         FormSideSheetTab(
           title: tr.navlink_screener_question_content,
@@ -313,5 +317,76 @@ class _MeasurementSurveyFormViewState
         ),
       ],
     );
+  }
+
+  List<Widget> _buildQuestionFormButtons(QuestionFormViewModel formViewModel) {
+    return [
+      DismissButton(
+        onPressed: () {
+          final navigator = Navigator.of(context);
+          formViewModel.cancel().then((_) {
+            if (mounted) navigator.maybePop();
+          });
+        },
+      ),
+      ReactiveFormConsumer(
+        builder: (context, form, child) {
+          final fitbitCredentialsFormViewModel =
+              formViewModel.fitbitCredentialsFormViewModel;
+          final requiresFitbitCredentials =
+              formViewModel.questionType == SurveyQuestionType.fitbit;
+
+          if (!requiresFitbitCredentials || fitbitCredentialsFormViewModel == null) {
+            final validationSummary = formViewModel.form.validationErrorSummary
+                .trim();
+            return PrimaryButton(
+              text: tr.dialog_save,
+              tooltipDisabled: _buildInvalidTooltip(validationSummary),
+              icon: null,
+              enabled: formViewModel.isValid,
+              onPressedFuture: formViewModel.isValid ? () {
+                final navigator = Navigator.of(context);
+                return formViewModel.save().then((_) {
+                  if (mounted) navigator.maybePop();
+                });
+              } : null,
+            );
+          }
+
+          return StreamBuilder(
+            stream: fitbitCredentialsFormViewModel.form.statusChanged,
+            builder: (context, _) {
+              final isValid =
+                  formViewModel.isValid &&
+                  fitbitCredentialsFormViewModel.form.valid;
+              final validationSummary = [
+                formViewModel.form.validationErrorSummary.trim(),
+                fitbitCredentialsFormViewModel.form.validationErrorSummary.trim(),
+              ].where((summary) => summary.trim().isNotEmpty).join('\n\n');
+
+              return PrimaryButton(
+                text: tr.dialog_save,
+                tooltipDisabled: _buildInvalidTooltip(validationSummary),
+                icon: null,
+                enabled: isValid,
+                onPressedFuture: isValid ? () {
+                  final navigator = Navigator.of(context);
+                  return formViewModel.save().then((_) {
+                    if (mounted) navigator.maybePop();
+                  });
+                } : null,
+              );
+            },
+          );
+        },
+      ),
+    ];
+  }
+
+  String _buildInvalidTooltip(String validationSummary) {
+    if (validationSummary.isEmpty) {
+      return tr.form_invalid_prompt;
+    }
+    return '${tr.form_invalid_prompt}\n\n$validationSummary';
   }
 }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -656,7 +656,10 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   void attachFitbitCredentialsFormViewModel(
     FitbitCredentialsFormViewModel fitbitCredentialsFormViewModel,
   ) {
-    if (identical(_fitbitCredentialsFormViewModel, fitbitCredentialsFormViewModel)) {
+    if (identical(
+      _fitbitCredentialsFormViewModel,
+      fitbitCredentialsFormViewModel,
+    )) {
       return;
     }
     _fitbitCredentialsFormViewModel = fitbitCredentialsFormViewModel;

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/domain/question.dart';
+import 'package:studyu_designer_v2/features/design/fitbit/fitbit_credentials_form_controller.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_conditional_form_controller.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_conditional_row_form_controller.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_data.dart';
@@ -424,6 +425,10 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     fitbitQuestionTypesControl.values.toList(),
   );
 
+  FitbitCredentialsFormViewModel? _fitbitCredentialsFormViewModel;
+  FitbitCredentialsFormViewModel? get fitbitCredentialsFormViewModel =>
+      _fitbitCredentialsFormViewModel;
+
   // - Form fields (question type-specific) - end
 
   late final Map<SurveyQuestionType, FormGroup> _controlsByQuestionType = {
@@ -483,8 +488,16 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
       StudyFormValidationSet.publish: [maxRecordingDurationValid],
     },
     SurveyQuestionType.fitbit: {
-      StudyFormValidationSet.draft: [fitbitTypeRequired],
-      StudyFormValidationSet.publish: [fitbitTypeRequired],
+      StudyFormValidationSet.draft: [
+        fitbitTypeRequired,
+        if (_fitbitCredentialsFormViewModel != null) fitbitClientIdRequired,
+        if (_fitbitCredentialsFormViewModel != null) fitbitClientSecretRequired,
+      ],
+      StudyFormValidationSet.publish: [
+        fitbitTypeRequired,
+        if (_fitbitCredentialsFormViewModel != null) fitbitClientIdRequired,
+        if (_fitbitCredentialsFormViewModel != null) fitbitClientSecretRequired,
+      ],
     },
   };
 
@@ -520,7 +533,23 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     ],
     validationMessages: {
       CountWhereValidator.kValidationMessageMinCount: (error) =>
-          "At least one Fitbit type must be selected.", //TODO: translations
+          tr.fitbit_question_type_required,
+    },
+  );
+
+  FormControlValidation get fitbitClientIdRequired => FormControlValidation(
+    control: _fitbitCredentialsFormViewModel!.clientIdControl,
+    validators: [Validators.required],
+    validationMessages: {
+      ValidationMessage.required: (_) => tr.fitbit_client_id_required,
+    },
+  );
+
+  FormControlValidation get fitbitClientSecretRequired => FormControlValidation(
+    control: _fitbitCredentialsFormViewModel!.clientSecretControl,
+    validators: [Validators.required],
+    validationMessages: {
+      ValidationMessage.required: (_) => tr.fitbit_client_secret_required,
     },
   );
 
@@ -622,6 +651,18 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     form.addAll(subtypeFormControls);
     markFormGroupChanged();
     onResponseOptionsChanged(answerOptionsControls);
+  }
+
+  void attachFitbitCredentialsFormViewModel(
+    FitbitCredentialsFormViewModel fitbitCredentialsFormViewModel,
+  ) {
+    if (identical(_fitbitCredentialsFormViewModel, fitbitCredentialsFormViewModel)) {
+      return;
+    }
+    _fitbitCredentialsFormViewModel = fitbitCredentialsFormViewModel;
+    fitbitCredentialsFormViewModel.enableQuestionValidation();
+    revalidate();
+    form.updateValueAndValidity();
   }
 
   @override
@@ -845,7 +886,20 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     if (freeTextTypeControl.value != FreeTextQuestionType.custom) {
       customRegexControl.value = null;
     }
-    return super.save();
+    if (questionType != SurveyQuestionType.fitbit ||
+        _fitbitCredentialsFormViewModel == null) {
+      return super.save();
+    }
+
+    final fitbitCredentialsFormViewModel = _fitbitCredentialsFormViewModel!;
+    fitbitCredentialsFormViewModel.revalidate();
+    fitbitCredentialsFormViewModel.form.updateValueAndValidity();
+
+    if (!fitbitCredentialsFormViewModel.form.valid) {
+      throw FormInvalidException();
+    }
+
+    return fitbitCredentialsFormViewModel.save().then((_) => super.save());
   }
 
   @override

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -65,11 +65,10 @@ class _SurveyQuestionFormViewState
           AudioRecordingQuestionFormView(formViewModel: formViewModel),
       SurveyQuestionType.freeText: (_) =>
           FreeTextQuestionFormView(formViewModel: formViewModel),
-      SurveyQuestionType.fitbit: (_) =>
-          FitbitQuestionFormView(
-            formViewModel: formViewModel,
-            studyId: widget.studyId,
-          ),
+      SurveyQuestionType.fitbit: (_) => FitbitQuestionFormView(
+        formViewModel: formViewModel,
+        studyId: widget.studyId,
+      ),
       SurveyQuestionType.pain: (_) =>
           PainQuestionFormView(formViewModel: formViewModel),
     };

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -17,8 +17,6 @@ import 'package:studyu_designer_v2/features/design/shared/questionnaire/question
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/question_type.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/scale_question_form_view.dart';
 import 'package:studyu_designer_v2/features/forms/form_validation.dart';
-import 'package:studyu_designer_v2/features/study/study_controller.dart';
-import 'package:studyu_designer_v2/localization/app_localizations.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/theme.dart';
 
@@ -53,15 +51,6 @@ class _SurveyQuestionFormViewState
     isStylingInformationDismissed = !isStylingInformationDismissed;
   });
 
-  bool _areFitbitCredentialsInvalid() {
-    final state = ref.watch(studyControllerProvider(widget.studyId));
-
-    final fitbitCredentials = state.studyValue?.fitbitCredentials;
-    return fitbitCredentials == null ||
-        fitbitCredentials.fitbitCredentials.clientId.isEmpty ||
-        fitbitCredentials.fitbitCredentials.clientSecret.isEmpty;
-  }
-
   WidgetBuilder get questionTypeBodyBuilder {
     final Map<SurveyQuestionType, WidgetBuilder> questionTypeWidgets = {
       SurveyQuestionType.choice: (_) =>
@@ -77,19 +66,13 @@ class _SurveyQuestionFormViewState
       SurveyQuestionType.freeText: (_) =>
           FreeTextQuestionFormView(formViewModel: formViewModel),
       SurveyQuestionType.fitbit: (_) =>
-          FitbitQuestionFormView(formViewModel: formViewModel),
+          FitbitQuestionFormView(
+            formViewModel: formViewModel,
+            studyId: widget.studyId,
+          ),
       SurveyQuestionType.pain: (_) =>
           PainQuestionFormView(formViewModel: formViewModel),
     };
-    //TODO: If question type is fitbit and credentials are not set, show a message to set credentials
-
-    if (formViewModel.questionType == SurveyQuestionType.fitbit &&
-        _areFitbitCredentialsInvalid()) {
-      return (_) => TextParagraph(
-        text: AppLocalizations.of(context)!.fitbit_credentials_not_set,
-        style: ThemeConfig.bodyTextMuted(Theme.of(context)),
-      );
-    }
 
     final questionType = formViewModel.questionType;
 
@@ -104,42 +87,40 @@ class _SurveyQuestionFormViewState
 
   @override
   Widget build(BuildContext context) {
-    return ReactiveFormConsumer(
-      builder: (context, formGroup, child) {
-        // Wrap everything in a [ReactiveFormConsumer] for convenience so that the
-        // sidesheet content is re-rendered when the form changes
-        //
-        // Note: if this becomes a performance issue, remove the
-        // ReactiveFormConsumer here & use consumers / listeners selectively for
-        // the UI parts that need to be rebuild
-        return PointerInterceptor(
-          child: SelectionArea(
-            child: Column(
-              children: [
-                _buildQuestionText(context),
-                if (isQuestionHelpTextFieldVisible)
-                  Column(
-                    children: [
-                      const SizedBox(height: 16.0),
-                      _buildQuestionHelpText(context),
-                    ],
-                  )
-                else
-                  const SizedBox.shrink(),
-                if (widget.isHtmlStyleable)
-                  HtmlStylingBanner(
-                    isDismissed: isStylingInformationDismissed,
-                    onDismissed: onDismissedCallback,
-                  ),
-                const SizedBox(height: 24.0),
-                _buildResponseTypeHeader(context),
-                const SizedBox(height: 16.0),
-                questionTypeBodyBuilder(context),
-              ],
+    return PointerInterceptor(
+      child: SelectionArea(
+        child: Column(
+          children: [
+            _buildQuestionText(context),
+            if (isQuestionHelpTextFieldVisible)
+              Column(
+                children: [
+                  const SizedBox(height: 16.0),
+                  _buildQuestionHelpText(context),
+                ],
+              )
+            else
+              const SizedBox.shrink(),
+            if (widget.isHtmlStyleable)
+              HtmlStylingBanner(
+                isDismissed: isStylingInformationDismissed,
+                onDismissed: onDismissedCallback,
+              ),
+            const SizedBox(height: 24.0),
+            ReactiveFormConsumer(
+              builder: (context, formGroup, child) {
+                return Column(
+                  children: [
+                    _buildResponseTypeHeader(context),
+                    const SizedBox(height: 16.0),
+                    questionTypeBodyBuilder(context),
+                  ],
+                );
+              },
             ),
-          ),
-        );
-      },
+          ],
+        ),
+      ),
     );
   }
 

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
@@ -24,7 +24,8 @@ class FitbitQuestionFormView extends ConsumerStatefulWidget {
       _FitbitQuestionFormViewState();
 }
 
-class _FitbitQuestionFormViewState extends ConsumerState<FitbitQuestionFormView> {
+class _FitbitQuestionFormViewState
+    extends ConsumerState<FitbitQuestionFormView> {
   QuestionFormViewModel get formViewModel => widget.formViewModel;
 
   @override

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
@@ -49,7 +49,7 @@ class _FitbitQuestionFormViewState
           rows: [
             FormTableRow(
               control: formViewModel.fitbitResponseOptionsArray,
-              label: tr.fitbit_question_title,
+              label: '',
               input: _FitbitTypeSelector(formViewModel: formViewModel),
             ),
           ],

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/fitbit_question_form_view.dart
@@ -2,17 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/common_views/form_table_layout.dart';
+import 'package:studyu_designer_v2/features/design/fitbit/fitbit_credentials_form_controller.dart';
+import 'package:studyu_designer_v2/features/design/fitbit/fitbit_credentials_form_view.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_controller.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/utils/string_extensions.dart';
 
-class FitbitQuestionFormView extends ConsumerWidget {
-  const FitbitQuestionFormView({required this.formViewModel, super.key});
+class FitbitQuestionFormView extends ConsumerStatefulWidget {
+  const FitbitQuestionFormView({
+    required this.formViewModel,
+    required this.studyId,
+    super.key,
+  });
 
   final QuestionFormViewModel formViewModel;
+  final String studyId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<FitbitQuestionFormView> createState() =>
+      _FitbitQuestionFormViewState();
+}
+
+class _FitbitQuestionFormViewState extends ConsumerState<FitbitQuestionFormView> {
+  QuestionFormViewModel get formViewModel => widget.formViewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final fitbitCredentialsFormViewModel = ref.watch(
+      fitbitCredentialsFormViewModelProvider(widget.studyId),
+    );
+    widget.formViewModel.attachFitbitCredentialsFormViewModel(
+      fitbitCredentialsFormViewModel,
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -20,53 +43,68 @@ class FitbitQuestionFormView extends ConsumerWidget {
           tr.fitbit_question_title,
           style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
         ),
-        const SizedBox(height: 8),
-        ReactiveFormArray(
-          formArray: formViewModel.fitbitResponseOptionsArray,
-          builder: (context, formArray, child) {
-            if (formArray.controls.isEmpty) {
-              return Text(tr.fitbit_question_type_empty);
-            }
-
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: FitbitQuestionType.values.asMap().entries.map((entry) {
-                final index = entry.key;
-                final type = entry.value;
-
-                return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4.0),
-                  child: Row(
-                    children: [
-                      ReactiveCheckbox(
-                        formControl:
-                            formArray.controls[index]
-                                as FormControl<bool>, // Cast control
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Row(
-                          children: [
-                            Text(
-                              type.name.toPascalCase(),
-                              style: const TextStyle(fontSize: 14),
-                            ),
-                            const SizedBox(width: 8),
-                            Tooltip(
-                              message: _getTranslation(type),
-                              child: const Icon(Icons.info_outline),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              }).toList(),
-            );
-          },
+        const SizedBox(height: 12),
+        FormTableLayout(
+          rows: [
+            FormTableRow(
+              control: formViewModel.fitbitResponseOptionsArray,
+              label: tr.fitbit_question_title,
+              input: _FitbitTypeSelector(formViewModel: formViewModel),
+            ),
+          ],
         ),
+        const SizedBox(height: 24),
+        FitbitCredentialsSection(formViewModel: fitbitCredentialsFormViewModel),
       ],
+    );
+  }
+}
+
+class _FitbitTypeSelector extends StatelessWidget {
+  const _FitbitTypeSelector({required this.formViewModel});
+
+  final QuestionFormViewModel formViewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ReactiveFormArray(
+      formArray: formViewModel.fitbitResponseOptionsArray,
+      builder: (context, formArray, child) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: FitbitQuestionType.values.asMap().entries.map((entry) {
+            final index = entry.key;
+            final type = entry.value;
+
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              child: Row(
+                children: [
+                  ReactiveCheckbox(
+                    formControl: formArray.controls[index] as FormControl<bool>,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Row(
+                      children: [
+                        Text(
+                          type.name.toPascalCase(),
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                        const SizedBox(width: 8),
+                        Tooltip(
+                          message: _getTranslation(type),
+                          child: const Icon(Icons.info_outline),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+        );
+      },
     );
   }
 

--- a/designer_v2/lib/features/forms/form_validation.dart
+++ b/designer_v2/lib/features/forms/form_validation.dart
@@ -162,12 +162,13 @@ extension FormGroupX on FormGroup {
   String get validationErrorSummary => getValidationErrorSummary();
 
   String getValidationErrorSummary({bool uniqueErrors = true}) {
-    final errorMessages = (uniqueErrors
-            ? {...formattedErrorMessages}.toList()
-            : formattedErrorMessages)
-        .map((message) => message.trim())
-        .where((message) => message.isNotEmpty)
-        .toList();
+    final errorMessages =
+        (uniqueErrors
+                ? {...formattedErrorMessages}.toList()
+                : formattedErrorMessages)
+            .map((message) => message.trim())
+            .where((message) => message.isNotEmpty)
+            .toList();
     if (errorMessages.isEmpty) {
       return '';
     }

--- a/designer_v2/lib/features/forms/form_validation.dart
+++ b/designer_v2/lib/features/forms/form_validation.dart
@@ -162,9 +162,15 @@ extension FormGroupX on FormGroup {
   String get validationErrorSummary => getValidationErrorSummary();
 
   String getValidationErrorSummary({bool uniqueErrors = true}) {
-    final errorMessages = uniqueErrors
-        ? {...formattedErrorMessages}.toList()
-        : formattedErrorMessages;
+    final errorMessages = (uniqueErrors
+            ? {...formattedErrorMessages}.toList()
+            : formattedErrorMessages)
+        .map((message) => message.trim())
+        .where((message) => message.isNotEmpty)
+        .toList();
+    if (errorMessages.isEmpty) {
+      return '';
+    }
     return "- ${errorMessages.join("\n- ")}";
   }
 }

--- a/designer_v2/lib/features/study/study_navbar.dart
+++ b/designer_v2/lib/features/study/study_navbar.dart
@@ -61,7 +61,6 @@ class StudyDesignNav {
     interventions(studyId),
     measurements(studyId),
     reports(studyId),
-    fitbitCredentials(studyId),
   ];
 
   static NavbarTab info(StudyID studyId) => NavbarTab(
@@ -88,10 +87,5 @@ class StudyDesignNav {
     index: 4,
     title: "Reports",
     intent: RoutingIntents.studyEditReports(studyId),
-  );
-  static NavbarTab fitbitCredentials(StudyID studyId) => NavbarTab(
-    index: 5,
-    title: "Fitbit",
-    intent: RoutingIntents.studyEditFitbitCredentials(studyId),
   );
 }

--- a/designer_v2/lib/localization/app_de.arb
+++ b/designer_v2/lib/localization/app_de.arb
@@ -823,6 +823,10 @@
   "client_secret": "Client Secret",
   "client_secret_label_help": "Geben Sie den Client Secret aus dem Fitbit Developer Portal ein.",
   "client_secret_hint": "Client Secret",
+  "fitbit_credentials_how_to_obtain": "So erhalten Sie Fitbit-Zugangsdaten",
+  "fitbit_client_id_required": "Client-ID ist erforderlich",
+  "fitbit_client_secret_required": "Client-Secret ist erforderlich",
+  "fitbit_question_type_required": "Mindestens ein Fitbit-Datentyp muss ausgewählt werden.",
   "screenshots_for_guidance": "Screenshots zur Anleitung:",
   "fitbit_credentials_not_set": "Fitbit-Anmeldedaten sind nicht gesetzt. Bitte navigieren Sie zum 'Fitbit'-Tab im Studien-Designer, um Ihre Fitbit-Client-ID und Ihr Client-Secret einzugeben. Sobald dies abgeschlossen ist, kehren Sie hierher zurück, um Fitbit-Fragen hinzuzufügen.",
   "fitbit_question_type_heartrate_description": "Erfasst die Herzfrequenz, gemessen jede Minute über den Tag verteilt.",
@@ -921,4 +925,3 @@
   "filter_button_clear": "Filter entfernen",
   "filter_button_main": "Filtern"
 }
-

--- a/designer_v2/lib/localization/app_en.arb
+++ b/designer_v2/lib/localization/app_en.arb
@@ -823,6 +823,10 @@
   "client_secret": "Client Secret",
   "client_secret_label_help": "Enter the Client Secret from Fitbit Developer Portal.",
   "client_secret_hint": "Client Secret",
+  "fitbit_credentials_how_to_obtain": "How to obtain Fitbit credentials",
+  "fitbit_client_id_required": "Client ID is required",
+  "fitbit_client_secret_required": "Client secret is required",
+  "fitbit_question_type_required": "At least one Fitbit type must be selected.",
   "screenshots_for_guidance": "Screenshots for Guidance:",
   "fitbit_credentials_not_set": "Fitbit credentials are not set. Please navigate to the 'Fitbit' tab in the study designer to enter your Fitbit client ID and client secret. Once completed, return here to add Fitbit questions.",
   "fitbit_question_type_heartrate_description": "Captures heart rate measured every minute throughout the day.",
@@ -921,4 +925,3 @@
   "filter_button_clear": "Clear filter",
   "filter_button_main": "Filter"
 }
-

--- a/designer_v2/lib/localization/app_localizations.dart
+++ b/designer_v2/lib/localization/app_localizations.dart
@@ -3837,6 +3837,30 @@ abstract class AppLocalizations {
   /// **'Client Secret'**
   String get client_secret_hint;
 
+  /// No description provided for @fitbit_credentials_how_to_obtain.
+  ///
+  /// In en, this message translates to:
+  /// **'How to obtain Fitbit credentials'**
+  String get fitbit_credentials_how_to_obtain;
+
+  /// No description provided for @fitbit_client_id_required.
+  ///
+  /// In en, this message translates to:
+  /// **'Client ID is required'**
+  String get fitbit_client_id_required;
+
+  /// No description provided for @fitbit_client_secret_required.
+  ///
+  /// In en, this message translates to:
+  /// **'Client secret is required'**
+  String get fitbit_client_secret_required;
+
+  /// No description provided for @fitbit_question_type_required.
+  ///
+  /// In en, this message translates to:
+  /// **'At least one Fitbit type must be selected.'**
+  String get fitbit_question_type_required;
+
   /// No description provided for @screenshots_for_guidance.
   ///
   /// In en, this message translates to:

--- a/designer_v2/lib/localization/app_localizations_de.dart
+++ b/designer_v2/lib/localization/app_localizations_de.dart
@@ -2271,6 +2271,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get client_secret_hint => 'Client Secret';
 
   @override
+  String get fitbit_credentials_how_to_obtain =>
+      'So erhalten Sie Fitbit-Zugangsdaten';
+
+  @override
+  String get fitbit_client_id_required => 'Client-ID ist erforderlich';
+
+  @override
+  String get fitbit_client_secret_required => 'Client-Secret ist erforderlich';
+
+  @override
+  String get fitbit_question_type_required =>
+      'Mindestens ein Fitbit-Datentyp muss ausgewählt werden.';
+
+  @override
   String get screenshots_for_guidance => 'Screenshots zur Anleitung:';
 
   @override

--- a/designer_v2/lib/localization/app_localizations_en.dart
+++ b/designer_v2/lib/localization/app_localizations_en.dart
@@ -2238,6 +2238,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get client_secret_hint => 'Client Secret';
 
   @override
+  String get fitbit_credentials_how_to_obtain =>
+      'How to obtain Fitbit credentials';
+
+  @override
+  String get fitbit_client_id_required => 'Client ID is required';
+
+  @override
+  String get fitbit_client_secret_required => 'Client secret is required';
+
+  @override
+  String get fitbit_question_type_required =>
+      'At least one Fitbit type must be selected.';
+
+  @override
   String get screenshots_for_guidance => 'Screenshots for Guidance:';
 
   @override

--- a/designer_v2/lib/routing/router_config.dart
+++ b/designer_v2/lib/routing/router_config.dart
@@ -22,7 +22,6 @@ import 'package:studyu_designer_v2/features/auth/signup_form_view.dart';
 import 'package:studyu_designer_v2/features/dashboard/dashboard_page.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_filter.dart';
 import 'package:studyu_designer_v2/features/design/enrollment/enrollment_form_view.dart';
-import 'package:studyu_designer_v2/features/design/fitbit/fitbit_credentials_form_view.dart';
 import 'package:studyu_designer_v2/features/design/info/study_info_form_view.dart';
 import 'package:studyu_designer_v2/features/design/interventions/intervention_form_controller.dart';
 import 'package:studyu_designer_v2/features/design/interventions/intervention_form_view.dart';
@@ -293,24 +292,6 @@ class RouterConf {
             selectedTab: StudyNav.edit(studyId),
             selectedTabSubnav: StudyDesignNav.reports(studyId),
             body: StudyDesignReportsFormView(studyId),
-            layoutType: SingleColumnLayoutType.boundedNarrow,
-          ),
-        );
-      },
-    ),
-    GoRoute(
-      path: "/studies/:${RouteParams.studyId}/edit/fitbitCredentials",
-      name: studyEditFitbitCredentialsRouteName,
-      pageBuilder: (context, state) {
-        final studyId = state.pathParameters[RouteParams.studyId]!;
-        return MaterialPage(
-          key: RouterKeys.studyKey,
-          child: StudyScaffold(
-            studyId: studyId,
-            tabsSubnav: StudyDesignNav.tabs(studyId),
-            selectedTab: StudyNav.edit(studyId),
-            selectedTabSubnav: StudyDesignNav.fitbitCredentials(studyId),
-            body: StudyDesignFitbitCredentialsFormView(studyId),
             layoutType: SingleColumnLayoutType.boundedNarrow,
           ),
         );

--- a/designer_v2/lib/routing/router_intent.dart
+++ b/designer_v2/lib/routing/router_intent.dart
@@ -55,10 +55,6 @@ class RoutingIntents {
     route: RouterConf.route(studyEditInfoRouteName),
     params: {RouteParams.studyId: studyId},
   );
-  static final studyEditFitbitCredentials = (StudyID studyId) => RoutingIntent(
-    route: RouterConf.route(studyEditFitbitCredentialsRouteName),
-    params: {RouteParams.studyId: studyId},
-  );
   static final studyEditEnrollment = (StudyID studyId) => RoutingIntent(
     route: RouterConf.route(studyEditEnrollmentRouteName),
     params: {RouteParams.studyId: studyId},


### PR DESCRIPTION
## Summary
- move Fitbit credentials and setup guidance into the Fitbit measurement question editor
- keep Fitbit credentials persisted separately from questionnaire data and remove the standalone Fitbit design tab/route
- require Fitbit type selection plus client ID and client secret before saving a Fitbit question
- localize the new Fitbit strings and reduce sidebar lag by collapsing and unloading the heavy tutorial content by default
- clean up validation tooltip formatting so empty messages do not render stray bullets or blank spacing

## How to test
1. Open Study Designer and go to `Measurements`.
2. Create a new question or edit an existing one and set the question type to `Fitbit`.
3. Verify the Fitbit editor shows:
   - Fitbit type checkboxes
   - client ID field
   - client secret field
   - a collapsed "How to obtain Fitbit credentials" section
4. Try saving the Fitbit question with no type selected and confirm save is blocked with the Fitbit type validation message.
5. Select a Fitbit type, clear client ID and/or client secret, and confirm save is blocked with the required-field validation messages.
6. Enter valid client ID and client secret, save the question, then reopen it and verify the credentials are still populated.
7. Check fitbit_credentials table has a saved record
8. Confirm there is no standalone `Fitbit` tab in Study Design anymore.
9. Expand and collapse the Fitbit help section and confirm the sidebar interaction feels responsive.
