### PR TITLE
Restore auto-dismiss behavior for designer snackbars

### DIFF
--- a/designer_v2/lib/services/notification_dispatcher.dart
+++ b/designer_v2/lib/services/notification_dispatcher.dart
@@ -221,6 +221,9 @@ class _NotificationDispatcherState
       duration: Duration(
         milliseconds: notification.duration ?? widget.snackbarDefaultDuration,
       ),
+      // Keep actionable snackbars auto-dismissing; Flutter now defaults
+      // `persist` to true when an action is present.
+      persist: false,
       padding: EdgeInsets.fromLTRB(
         2.5 * widget.snackbarInnerPadding,
         widget.snackbarInnerPadding,


### PR DESCRIPTION
## Summary

This PR restores the previous auto-dismiss behavior for designer snackbars.

## Root cause

The shared snackbar dispatcher always adds an action button (`X`).
In the current Flutter SDK, snackbars with an action default to `persist = true`,
which caused snackbar notifications to remain visible until manually dismissed.

## Fix

Set `persist: false` in the shared snackbar builder so actionable snackbars
continue to auto-dismiss after their configured duration.

## Affected behavior

This fixes shared snackbar notifications such as:
- wrong password / invalid credentials messages
- delete study confirmation feedback
- other designer snackbar messages routed through the notification dispatcher