### PR TITLE
Add sortable serial column to studies table

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_state.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_state.dart
@@ -115,6 +115,16 @@ class DashboardState extends Equatable {
   }) {
     final sortedStudies = studiesToSort ?? studies.value!;
     switch (sortByColumn) {
+      case StudiesTableColumn.serial:
+        if (!sortAscending) {
+          sortedStudies.sort(
+            (study, other) => other.createdAt!.compareTo(study.createdAt!),
+          );
+        } else {
+          sortedStudies.sort(
+            (study, other) => study.createdAt!.compareTo(other.createdAt!),
+          );
+        }
       case StudiesTableColumn.title:
         if (sortAscending) {
           sortedStudies.sort(

--- a/designer_v2/lib/features/dashboard/studies_table.dart
+++ b/designer_v2/lib/features/dashboard/studies_table.dart
@@ -8,8 +8,10 @@ import 'package:studyu_designer_v2/features/dashboard/dashboard_controller.dart'
 import 'package:studyu_designer_v2/features/dashboard/studies_table_column_header.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_table_item.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/localization/string_hardcoded.dart';
 
 enum StudiesTableColumn {
+  serial,
   pin,
   title,
   status,
@@ -81,6 +83,13 @@ class StudiesTable extends StatelessWidget {
       return emptyWidget;
     }
 
+    final serialNumberByStudyId = <String, int>{};
+    final studiesBySerial = [...studies]
+      ..sort((study, other) => study.createdAt!.compareTo(other.createdAt!));
+    for (int index = 0; index < studiesBySerial.length; index++) {
+      serialNumberByStudyId[studiesBySerial[index].id] = index + 1;
+    }
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final isCompact = constraints.maxWidth < compactWidthThreshold;
@@ -126,6 +135,9 @@ class StudiesTable extends StatelessWidget {
 
         // Set column definitions
         final columnDefinitionsMap = {
+          StudiesTableColumn.serial: StudiesTableColumnSize.fixedWidth(
+            itemHeight,
+          ),
           StudiesTableColumn.pin: StudiesTableColumnSize.fixedWidth(itemHeight),
           StudiesTableColumn.title: StudiesTableColumnSize.flexWidth(32),
           StudiesTableColumn.status: StudiesTableColumnSize.fixedWidth(
@@ -158,78 +170,17 @@ class StudiesTable extends StatelessWidget {
               height: itemHeight,
               child: Row(
                 children: [
-                  columnDefinitions[0].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[0].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[0].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[1].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[1].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[1].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[2].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[2].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[2].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[3].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[3].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[3].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[4].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[4].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[4].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[5].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[5].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[5].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[6].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[6].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[6].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[7].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[7].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[7].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[8].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[8].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[8].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
+                  for (int index = 0; index < columnDefinitions.length; index++)
+                    ...[
+                      columnDefinitions[index].value.createContainer(
+                        child: _buildColumnHeader(columnDefinitions[index].key),
+                      ),
+                      SizedBox(
+                        width: columnDefinitions[index].value.collapsed
+                            ? 0
+                            : columnSpacing,
+                      ),
+                    ],
                 ],
               ),
             ),
@@ -242,6 +193,7 @@ class StudiesTable extends StatelessWidget {
                 final item = studies[index];
                 return StudiesTableItem(
                   study: item,
+                  serialNumber: serialNumberByStudyId[item.id] ?? (index + 1),
                   columnSizes: columnDefinitionsMap.values.toList(),
                   actions: getActions(item),
                   isPinned: pinnedStudies.contains(item.id),
@@ -268,6 +220,8 @@ class StudiesTable extends StatelessWidget {
     switch (column) {
       case StudiesTableColumn.title:
         title = tr.studies_list_header_title;
+      case StudiesTableColumn.serial:
+        title = 'Serial'.hardcoded;
       case StudiesTableColumn.status:
         title = tr.studies_list_header_status;
       case StudiesTableColumn.participation:

--- a/designer_v2/lib/features/dashboard/studies_table_item.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_item.dart
@@ -12,6 +12,7 @@ import 'package:studyu_designer_v2/utils/model_action.dart';
 
 class StudiesTableItem extends StatefulWidget {
   final Study study;
+  final int serialNumber;
   final double itemHeight;
   final double itemPadding;
   final double rowSpacing;
@@ -25,6 +26,7 @@ class StudiesTableItem extends StatefulWidget {
   const StudiesTableItem({
     super.key,
     required this.study,
+    required this.serialNumber,
     required this.actions,
     required this.columnSizes,
     required this.isPinned,
@@ -34,7 +36,7 @@ class StudiesTableItem extends StatefulWidget {
     this.itemPadding = 10.0,
     this.rowSpacing = 9.0,
     this.columnSpacing = 10.0,
-  }) : assert(columnSizes.length == 9);
+  }) : assert(columnSizes.length == 10);
 
   @override
   State<StudiesTableItem> createState() => _StudiesTableItemState();
@@ -94,6 +96,19 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                 child: Row(
                   children: [
                     widget.columnSizes[0].createContainer(
+                      child: Center(
+                        child: Text(
+                          widget.serialNumber.toString(),
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[0].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[1].createContainer(
                       height: widget.itemHeight,
                       child: MouseEventsRegion(
                         onTap: () => widget.onPinnedChanged?.call(
@@ -108,11 +123,11 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                       ),
                     ),
                     SizedBox(
-                      width: widget.columnSizes[0].collapsed
+                      width: widget.columnSizes[1].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),
-                    widget.columnSizes[1].createContainer(
+                    widget.columnSizes[2].createContainer(
                       child: Text(
                         widget.study.title ?? '[Missing study title]',
                         maxLines: 3,
@@ -120,11 +135,11 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                       ),
                     ),
                     SizedBox(
-                      width: widget.columnSizes[1].collapsed
+                      width: widget.columnSizes[2].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),
-                    widget.columnSizes[2].createContainer(
+                    widget.columnSizes[3].createContainer(
                       child: Center(
                         child: StudyStatusBadge(
                           status: widget.study.status,
@@ -134,28 +149,13 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                       ),
                     ),
                     SizedBox(
-                      width: widget.columnSizes[2].collapsed
-                          ? 0
-                          : widget.columnSpacing,
-                    ),
-                    widget.columnSizes[3].createContainer(
-                      child: StudyParticipationBadge(
-                        participation: widget.study.participation,
-                      ),
-                    ),
-                    SizedBox(
                       width: widget.columnSizes[3].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[4].createContainer(
-                      child: Center(
-                        child: Text(
-                          widget.study.createdAt?.toTimeAgoString() ?? '',
-                          maxLines: 3,
-                          overflow: TextOverflow.fade,
-                          textAlign: TextAlign.center,
-                        ),
+                      child: StudyParticipationBadge(
+                        participation: widget.study.participation,
                       ),
                     ),
                     SizedBox(
@@ -166,10 +166,10 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     widget.columnSizes[5].createContainer(
                       child: Center(
                         child: Text(
-                          widget.study.participantCount.toString(),
-                          style: mutedTextStyleIfZero(
-                            widget.study.participantCount,
-                          ),
+                          widget.study.createdAt?.toTimeAgoString() ?? '',
+                          maxLines: 3,
+                          overflow: TextOverflow.fade,
+                          textAlign: TextAlign.center,
                         ),
                       ),
                     ),
@@ -181,9 +181,9 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     widget.columnSizes[6].createContainer(
                       child: Center(
                         child: Text(
-                          widget.study.activeSubjectCount.toString(),
+                          widget.study.participantCount.toString(),
                           style: mutedTextStyleIfZero(
-                            widget.study.activeSubjectCount,
+                            widget.study.participantCount,
                           ),
                         ),
                       ),
@@ -196,8 +196,10 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     widget.columnSizes[7].createContainer(
                       child: Center(
                         child: Text(
-                          widget.study.endedCount.toString(),
-                          style: mutedTextStyleIfZero(widget.study.endedCount),
+                          widget.study.activeSubjectCount.toString(),
+                          style: mutedTextStyleIfZero(
+                            widget.study.activeSubjectCount,
+                          ),
                         ),
                       ),
                     ),
@@ -207,10 +209,23 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[8].createContainer(
-                      child: _buildActionMenu(context, widget.actions),
+                      child: Center(
+                        child: Text(
+                          widget.study.endedCount.toString(),
+                          style: mutedTextStyleIfZero(widget.study.endedCount),
+                        ),
+                      ),
                     ),
                     SizedBox(
                       width: widget.columnSizes[8].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[9].createContainer(
+                      child: _buildActionMenu(context, widget.actions),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[9].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),


### PR DESCRIPTION
## Summary

This PR adds a serial column to the studies table and makes it sortable.

## Changes

- add a dedicated `Serial` column to the studies table
- display stable serial numbers for visible studies
- allow sorting by the serial column
- keep the displayed serial values aligned with the serial sort order

## Notes

The serial value is a table-level ordering aid for the studies list.
It is computed from study creation order for the currently visible study set.


<img width="1592" height="472" alt="image" src="https://github.com/user-attachments/assets/bf229083-363a-46e6-853d-f92025b574d4" />
