### PR TITLE
Improve studies table header typography

### DIFF
--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -31,6 +31,12 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final headerTextStyle =
+        (theme.textTheme.labelLarge ?? theme.textTheme.bodyMedium)!.copyWith(
+          fontWeight: FontWeight.w700,
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.88),
+          letterSpacing: 0.15,
+        );
 
     return MouseEventsRegion(
       key: ValueKey('studies_table_column_header_${widget.title}'),
@@ -47,11 +53,7 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
                 overflow: TextOverflow.fade,
                 softWrap: false,
                 textAlign: widget.center ? TextAlign.center : TextAlign.start,
-                style: theme.textTheme.labelMedium!.copyWith(
-                  fontWeight: FontWeight.w700,
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.88),
-                  letterSpacing: 0.15,
-                ),
+                style: headerTextStyle,
               ),
             ),
             if (widget.sortable)

--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -47,8 +47,10 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
                 overflow: TextOverflow.fade,
                 softWrap: false,
                 textAlign: widget.center ? TextAlign.center : TextAlign.start,
-                style: theme.textTheme.bodySmall!.copyWith(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+                style: theme.textTheme.labelMedium!.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.88),
+                  letterSpacing: 0.15,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary

Adjust studies table header typography for better readability and hierarchy.

## Changes

- use `labelMedium` for header labels
- increase header text weight (`w700`)
- slightly increase contrast
- add subtle letter spacing for clearer scanning

## Scope

Only updates studies table header presentation.
No behavior, sorting, or data logic changes.

<img width="1572" height="566" alt="image" src="https://github.com/user-attachments/assets/91f81875-3cf4-4ddd-8e28-8fe4bb258a31" />
