### PR TITLE
Add `Actions` header for the studies table action column

### DIFF
--- a/designer_v2/lib/features/dashboard/studies_table.dart
+++ b/designer_v2/lib/features/dashboard/studies_table.dart
@@ -281,8 +281,9 @@ class StudiesTable extends StatelessWidget {
       case StudiesTableColumn.completed:
         title = tr.studies_list_header_participants_completed;
       case StudiesTableColumn.pin:
-      case StudiesTableColumn.action:
         title = '';
+      case StudiesTableColumn.action:
+        title = 'Actions';
     }
 
     final sortAscending = dashboardController.isSortAscending;


### PR DESCRIPTION
### Summary
Adds a visible header label for the last column in the studies table so the column purpose is clear.

### Changes
- Updated `designer_v2/lib/features/dashboard/studies_table.dart`.
- Set the `StudiesTableColumn.action` header title to `Actions`.
- Kept the action column non-sortable (no sorting behavior added).

### Scope
- UI-only table header labeling change.
- No data, backend, or sorting logic behavior changes.

### Validation
- Verified the studies table now shows `Actions` as the last column header.
- Verified the `Actions` column remains non-sortable.