### PR TITLE
feat(dashboard): add bulk study actions with progress and reliable sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ megalinter-reports/
 
 # No localization file on workspace level
 l10n-missing.txt
+
+# Local Codex instructions
+AGENTS.md

--- a/designer_v2/lib/features/analyze/study_export_zip.dart
+++ b/designer_v2/lib/features/analyze/study_export_zip.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:archive/archive.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
@@ -14,6 +16,11 @@ extension StudyExportZipX on StudyExportData {
     final toCSVString = CSVStringEncoder();
     final toJsonString = JsonStringEncoder();
 
+    developer.log(
+      'Building export archive for study ${study.id} (${study.title})',
+      name: 'StudyExportZip',
+    );
+
     final files = {
       'study_definition.json': prettyJson(study.toJson()),
       'measurements.csv': toCSVString(measurementsData),
@@ -28,11 +35,19 @@ extension StudyExportZipX on StudyExportData {
     });
 
     for (final mediaFile in mediaData) {
+      developer.log(
+        'Downloading media asset for export: $mediaFile',
+        name: 'StudyExportZip',
+      );
       final content = await BlobStorageHandler().downloadObservation(mediaFile);
       final archiveFile = ArchiveFile(mediaFile, content.length, content);
       archive.addFile(archiveFile);
     }
 
+    developer.log(
+      'Archive build complete for study ${study.id}; files=${archive.length}',
+      name: 'StudyExportZip',
+    );
     return archive;
   }
 
@@ -43,10 +58,25 @@ extension StudyExportZipX on StudyExportData {
 
   Future downloadAsZip({String? filename}) async {
     filename ??= defaultFilename;
-    return downloadBytes(
-      bytes: (await encodedZip)!,
-      filename: filename.ensureSuffix('.zip'),
-    );
+    try {
+      final zipBytes = (await encodedZip)!;
+      developer.log(
+        'Downloading zip for study ${study.id} as ${filename.ensureSuffix('.zip')} (${zipBytes.length} bytes)',
+        name: 'StudyExportZip',
+      );
+      return downloadBytes(
+        bytes: zipBytes,
+        filename: filename.ensureSuffix('.zip'),
+      );
+    } catch (error, stackTrace) {
+      developer.log(
+        'Zip export failed for study ${study.id} (${study.title}): $error',
+        name: 'StudyExportZip',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
   }
 }
 

--- a/designer_v2/lib/features/dashboard/dashboard_controller.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_controller.dart
@@ -1,21 +1,50 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
+import 'package:flutter/material.dart'
+    show
+        BorderRadius,
+        BoxConstraints,
+        BoxDecoration,
+        Column,
+        ConstrainedBox,
+        Container,
+        CrossAxisAlignment,
+        Colors,
+        EdgeInsets,
+        FontWeight,
+        Icon,
+        Icons,
+        ListTile,
+        MainAxisSize,
+        Row,
+        SingleChildScrollView,
+        SizedBox,
+        Text,
+        TextStyle;
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/common_views/search.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
+import 'package:studyu_designer_v2/domain/study_export.dart';
 import 'package:studyu_designer_v2/features/dashboard/dashboard_state.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_filter.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_filter/filter_types.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_table.dart';
+import 'package:studyu_designer_v2/features/analyze/study_export_zip.dart';
 import 'package:studyu_designer_v2/features/study/study_actions.dart';
 import 'package:studyu_designer_v2/repositories/auth_repository.dart';
+import 'package:studyu_designer_v2/repositories/api_client.dart';
 import 'package:studyu_designer_v2/repositories/model_repository.dart';
 import 'package:studyu_designer_v2/repositories/study_repository.dart';
 import 'package:studyu_designer_v2/repositories/user_repository.dart';
 import 'package:studyu_designer_v2/routing/router.dart';
 import 'package:studyu_designer_v2/routing/router_intent.dart';
+import 'package:studyu_designer_v2/services/notification_service.dart';
+import 'package:studyu_designer_v2/services/notification_types.dart';
+import 'package:studyu_designer_v2/services/notifications.dart';
+import 'package:studyu_designer_v2/localization/string_hardcoded.dart';
 import 'package:studyu_designer_v2/utils/model_action.dart';
 
 part 'dashboard_controller.g.dart';
@@ -58,6 +87,23 @@ class DashboardController extends _$DashboardController
 
   /// A subscription for synchronizing state between the repository and the controller
   StreamSubscription<List<WrappedModel<Study>>>? _studiesSubscription;
+
+  NotificationService get _notificationService =>
+      ref.read(notificationServiceProvider);
+
+  void _setBulkActionInProgress(bool value, {int totalCount = 0}) {
+    state = state.copyWith(
+      isBulkActionInProgress: value,
+      bulkActionCompletedCount: value ? 0 : 0,
+      bulkActionTotalCount: value ? totalCount : 0,
+    );
+  }
+
+  void _advanceBulkActionProgress() {
+    state = state.copyWith(
+      bulkActionCompletedCount: state.bulkActionCompletedCount + 1,
+    );
+  }
 
   Future<void> _loadUserPreferences() async {
     try {
@@ -168,6 +214,629 @@ class DashboardController extends _$DashboardController
   Future<void> pinOffStudy(String modelId) async {
     await _userRepository.updatePreferences(PreferenceAction.pinOff, modelId);
     sortStudies();
+  }
+
+  void toggleStudySelection(String studyId) {
+    final updatedSelection = {...state.selectedStudyIds};
+    if (!updatedSelection.add(studyId)) {
+      updatedSelection.remove(studyId);
+    }
+    state = state.copyWith(selectedStudyIds: updatedSelection);
+  }
+
+  void setStudySelection(String studyId, bool selected) {
+    final updatedSelection = {...state.selectedStudyIds};
+    if (selected) {
+      updatedSelection.add(studyId);
+    } else {
+      updatedSelection.remove(studyId);
+    }
+    state = state.copyWith(selectedStudyIds: updatedSelection);
+  }
+
+  void toggleSelectAllVisibleStudies(List<Study> visibleStudies) {
+    final visibleIds = visibleStudies.map((study) => study.id).toSet();
+    final allVisibleSelected = visibleIds.isNotEmpty &&
+        visibleIds.every(state.selectedStudyIds.contains);
+
+    final updatedSelection = {...state.selectedStudyIds};
+    if (allVisibleSelected) {
+      updatedSelection.removeAll(visibleIds);
+    } else {
+      updatedSelection.addAll(visibleIds);
+    }
+    state = state.copyWith(selectedStudyIds: updatedSelection);
+  }
+
+  void confirmDeleteSelectedStudies() {
+    final selectedCount = state.selectedStudyIds.length;
+    if (selectedCount == 0) {
+      return;
+    }
+
+    _notificationService.show(
+      AlertIntent(
+        title: 'Delete selected studies?'.hardcoded,
+        message:
+            'This will permanently delete $selectedCount selected studies.'
+                .hardcoded,
+        icon: Icons.delete_rounded,
+        actions: [NotificationDefaultActions.cancel],
+      ),
+      actions: [
+        NotificationAction(
+          label: StudyActionType.delete.string,
+          isDestructive: true,
+          onSelect: deleteSelectedStudies,
+        ),
+      ],
+    );
+  }
+
+  void confirmDuplicateSelectedStudies() {
+    final selectedCount = state.selectedStudyIds.length;
+    if (selectedCount == 0) {
+      return;
+    }
+
+    _notificationService.show(
+      AlertIntent(
+        title: 'Duplicate selected studies?'.hardcoded,
+        message:
+            'This will create draft copies of $selectedCount selected studies.'
+                .hardcoded,
+        icon: Icons.file_copy_rounded,
+        actions: [NotificationDefaultActions.cancel],
+      ),
+      actions: [
+        NotificationAction(
+          label: StudyActionType.duplicate.string,
+          onSelect: duplicateSelectedStudies,
+        ),
+      ],
+    );
+  }
+
+  Future<void> deleteSelectedStudies() async {
+    final selectedIds = [...state.selectedStudyIds];
+    if (selectedIds.isEmpty) {
+      return;
+    }
+
+    _setBulkActionInProgress(true, totalCount: selectedIds.length);
+    try {
+      final studies = state.studies.value ?? const <Study>[];
+      final studyTitlesById = {
+        for (final study in studies)
+          study.id: (study.title ?? 'Untitled study'.hardcoded),
+      };
+      final deletedIds = <String>{};
+      final failedStudies = <({String title, String reason})>[];
+
+      for (final studyId in selectedIds) {
+        try {
+          await _studyRepository.deletePersisted(studyId);
+          deletedIds.add(studyId);
+        } catch (error) {
+          final reason = _describeDeleteError(error);
+          failedStudies.add(
+            (
+              title:
+                  studyTitlesById[studyId] ?? 'Study $studyId'.hardcoded,
+              reason: reason,
+            ),
+          );
+        } finally {
+          _advanceBulkActionProgress();
+        }
+      }
+
+      final refreshedStudies = await _studyRepository.fetchAll();
+      final remainingIds = refreshedStudies.map((wrapped) => wrapped.model.id).toSet();
+      final verifiedDeletedIds = deletedIds.where((id) => !remainingIds.contains(id)).toSet();
+      final unverifiedDeletedIds = deletedIds.difference(verifiedDeletedIds);
+      for (final studyId in unverifiedDeletedIds) {
+        failedStudies.add(
+          (
+            title: studyTitlesById[studyId] ?? 'Study $studyId'.hardcoded,
+            reason:
+                'Deletion was requested but the study still exists after refresh.'
+                    .hardcoded,
+          ),
+        );
+      }
+
+      final remainingSelection = {...state.selectedStudyIds}
+        ..removeAll(verifiedDeletedIds);
+      state = state.copyWith(selectedStudyIds: remainingSelection);
+
+      if (failedStudies.isEmpty) {
+        _notificationService.showMessage(
+          'Deleted ${verifiedDeletedIds.length} studies.'.hardcoded,
+        );
+        return;
+      }
+
+      if (verifiedDeletedIds.isEmpty) {
+        _notificationService.show(
+          AlertIntent(
+            title: 'Delete failed'.hardcoded,
+            customContent: SizedBox(
+              width: 520,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'None of the selected studies could be deleted.'
+                        .hardcoded,
+                  ),
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.redAccent.withValues(alpha: 0.10),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.error_outline_rounded,
+                          color: Colors.red,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Failed deletions'.hardcoded,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                            color: Colors.red,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 240),
+                    child: SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          for (final study in failedStudies)
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              dense: true,
+                              leading: const Icon(
+                                Icons.error_outline_rounded,
+                                color: Colors.red,
+                              ),
+                              title: Text(study.title, maxLines: 2),
+                              subtitle: Text(
+                                study.reason,
+                                style: const TextStyle(color: Colors.red),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            icon: Icons.delete_rounded,
+            actions: [NotificationDefaultActions.cancel],
+          ),
+        );
+        return;
+      }
+
+      _notificationService.show(
+        AlertIntent(
+          title: 'Delete completed with issues'.hardcoded,
+          customContent: SizedBox(
+            width: 520,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Deleted ${verifiedDeletedIds.length} studies. ${failedStudies.length} could not be deleted.'
+                      .hardcoded,
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.redAccent.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(
+                        Icons.error_outline_rounded,
+                        color: Colors.red,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Failed deletions'.hardcoded,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          color: Colors.red,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 240),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        for (final study in failedStudies)
+                          ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            dense: true,
+                            leading: const Icon(
+                              Icons.error_outline_rounded,
+                              color: Colors.red,
+                            ),
+                            title: Text(study.title, maxLines: 2),
+                            subtitle: Text(
+                              study.reason,
+                              style: const TextStyle(color: Colors.red),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          icon: Icons.delete_rounded,
+          actions: [NotificationDefaultActions.cancel],
+        ),
+      );
+    } finally {
+      _setBulkActionInProgress(false);
+    }
+  }
+
+  Future<void> duplicateSelectedStudies() async {
+    final selectedIds = state.selectedStudyIds;
+    if (selectedIds.isEmpty) {
+      return;
+    }
+
+    _setBulkActionInProgress(true, totalCount: selectedIds.length);
+    try {
+      final studies = state.studies.value ?? const <Study>[];
+      final selectedStudies = studies
+          .where((study) => selectedIds.contains(study.id))
+          .toList();
+
+      final duplicatedIds = <String>{};
+      final failedIds = <String>{};
+
+      for (final study in selectedStudies) {
+        try {
+          await _studyRepository.duplicateAndSavePersisted(study);
+          duplicatedIds.add(study.id);
+        } catch (_) {
+          failedIds.add(study.id);
+        } finally {
+          _advanceBulkActionProgress();
+        }
+      }
+
+      await _studyRepository.fetchAll();
+
+      if (failedIds.isEmpty) {
+        _notificationService.showMessage(
+          'Created ${duplicatedIds.length} study copies.'.hardcoded,
+        );
+        return;
+      }
+
+      if (duplicatedIds.isEmpty) {
+        _notificationService.showMessage(
+          'Could not duplicate the selected studies.'.hardcoded,
+        );
+        return;
+      }
+
+      _notificationService.showMessage(
+        'Created ${duplicatedIds.length} study copies. ${failedIds.length} failed.'
+            .hardcoded,
+      );
+    } finally {
+      _setBulkActionInProgress(false);
+    }
+  }
+
+  Future<void> exportSelectedStudies() async {
+    final selectedIds = state.selectedStudyIds;
+    if (selectedIds.isEmpty) {
+      return;
+    }
+
+    final currentUser = _authRepository.currentUser;
+    if (currentUser == null) {
+      return;
+    }
+
+    _setBulkActionInProgress(true, totalCount: selectedIds.length);
+    try {
+      final exportedIds = <String>{};
+      final failedIds = <String>{};
+      final skippedStudies = <({String title, String reason})>[];
+      final failedStudies = <({String title, String reason})>[];
+
+      for (final studyId in selectedIds) {
+        try {
+          developer.log(
+            'Fetching full study for export: $studyId',
+            name: 'DashboardController.bulkExport',
+          );
+          final study = (await _studyRepository.fetch(studyId)).model;
+
+          developer.log(
+            'Fetched full study ${study.id} (${study.title}); participants=${study.participants?.length ?? 0}, progress=${study.participantsProgress?.length ?? 0}',
+            name: 'DashboardController.bulkExport',
+          );
+
+          if (!study.canExport(currentUser)) {
+            final reason =
+                study.exportDisabledReason(currentUser) ??
+                'Export is unavailable.'.hardcoded;
+            skippedStudies.add(
+              (
+                title: study.title ?? 'Untitled study'.hardcoded,
+                reason: reason,
+              ),
+            );
+            developer.log(
+              'Bulk export skipped study ${study.id} (${study.title}) because export is unavailable: $reason',
+              name: 'DashboardController.bulkExport',
+            );
+            continue;
+          }
+
+          developer.log(
+            'Starting export for study ${study.id} (${study.title})',
+            name: 'DashboardController.bulkExport',
+          );
+          await study.exportData.downloadAsZip();
+          exportedIds.add(study.id);
+          developer.log(
+            'Export completed for study ${study.id} (${study.title})',
+            name: 'DashboardController.bulkExport',
+          );
+        } catch (error, stackTrace) {
+          failedIds.add(studyId);
+          failedStudies.add(
+            (
+              title: 'Study $studyId'.hardcoded,
+              reason: 'Export failed due to an unexpected error.'.hardcoded,
+            ),
+          );
+          developer.log(
+            'Export failed for study $studyId: $error',
+            name: 'DashboardController.bulkExport',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        } finally {
+          _advanceBulkActionProgress();
+        }
+      }
+
+      if (failedIds.isEmpty && skippedStudies.isEmpty) {
+        _notificationService.showMessage(
+          'Started export for ${exportedIds.length} studies.'.hardcoded,
+        );
+        return;
+      }
+
+      final summary = <String>[];
+      if (exportedIds.isNotEmpty) {
+        summary.add(
+          'Started export for ${exportedIds.length} studies.'.hardcoded,
+        );
+      }
+      if (skippedStudies.isNotEmpty) {
+        summary.add(
+          '${skippedStudies.length} studies could not be exported.'.hardcoded,
+        );
+      }
+      if (failedIds.isNotEmpty) {
+        summary.add('${failedIds.length} failed during export.'.hardcoded);
+      }
+
+      _notificationService.show(
+        AlertIntent(
+          title: 'Export completed with issues'.hardcoded,
+          customContent: SizedBox(
+            width: 520,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(summary.join(' ')),
+                if (skippedStudies.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.orange.withValues(alpha: 0.14),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.warning_amber_rounded,
+                          color: Colors.deepOrange,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Not exported'.hardcoded,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                            color: Colors.deepOrange,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 240),
+                    child: SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          for (final study in skippedStudies)
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              dense: true,
+                              leading: const Icon(
+                                Icons.warning_amber_rounded,
+                                color: Colors.deepOrange,
+                              ),
+                              title: Text(study.title, maxLines: 2),
+                              subtitle: Text(
+                                study.reason,
+                                style: const TextStyle(
+                                  color: Colors.deepOrange,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+                if (failedStudies.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.redAccent.withValues(alpha: 0.10),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.error_outline_rounded,
+                          color: Colors.red,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Failed'.hardcoded,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                            color: Colors.red,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Column(
+                    children: [
+                      for (final study in failedStudies)
+                        ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          dense: true,
+                          leading: const Icon(
+                            Icons.error_outline_rounded,
+                            color: Colors.red,
+                          ),
+                          title: Text(study.title, maxLines: 2),
+                          subtitle: Text(
+                            study.reason,
+                            style: const TextStyle(color: Colors.red),
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          icon: Icons.download_rounded,
+          actions: [NotificationDefaultActions.cancel],
+        ),
+      );
+    } finally {
+      _setBulkActionInProgress(false);
+    }
+  }
+
+  String _describeDeleteError(Object error) {
+    if (error case APIException apiError) {
+      if (apiError.statusCode == '409' || apiError.statusCode == '23503') {
+        return _describeDeleteConflict(apiError);
+      }
+      if (apiError.message != null && apiError.message!.trim().isNotEmpty) {
+        final message = apiError.message!.trim();
+        if (_looksLikeInviteConflict(message)) {
+          return 'This study still has invite codes linked to it. Delete the invite codes first, then delete the study.'
+              .hardcoded;
+        }
+        return message.hardcoded;
+      }
+    }
+
+    final raw = error.toString();
+    if (_looksLikeInviteConflict(raw)) {
+      return 'This study still has invite codes linked to it. Delete the invite codes first, then delete the study.'
+          .hardcoded;
+    }
+    if (raw.contains('23503')) {
+      return 'This study cannot be deleted because other data still references it.'
+          .hardcoded;
+    }
+    return 'Could not delete this study because the server rejected the request.'
+        .hardcoded;
+  }
+
+  bool _looksLikeInviteConflict(String text) {
+    return text.contains('study_invite_studyId_fkey') ||
+        text.contains('study_invite') ||
+        text.contains('invite code') ||
+        text.contains('Key is still referenced from table "study_invite"');
+  }
+
+  String _describeDeleteConflict(APIException error) {
+    final detail = error.details?.toString().trim();
+    final message = error.message?.trim();
+
+    if (_looksLikeInviteConflict(message ?? '') ||
+        _looksLikeInviteConflict(detail ?? '')) {
+      return 'This study still has invite codes linked to it. Delete the invite codes first, then delete the study.'
+          .hardcoded;
+    }
+
+    if (detail != null && detail.isNotEmpty && detail != 'null') {
+      return detail.hardcoded;
+    }
+    if (message != null && message.isNotEmpty) {
+      return message.hardcoded;
+    }
+    return 'The server reported a conflict while deleting this study. Dependent data may still reference it.'
+        .hardcoded;
   }
 
   void setSorting(StudiesTableColumn sortByColumn, bool ascending) {

--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -206,9 +206,13 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     return DashboardScaffold(
       scaffoldKey: _scaffoldKey,
       endDrawer: const Drawer(width: 400, child: FilterBuilder()),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
+      body: Stack(
+        children: [
+          AbsorbPointer(
+            absorbing: state.isBulkActionInProgress,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
           Row(
             children: [
               SizedBox(
@@ -516,54 +520,216 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
             ),
           ],
           const SizedBox(height: 24.0), // spacing between body elements
-          FutureBuilder<StudyUUser>(
-            future: ref.read(userRepositoryProvider).fetchUser(),
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return AsyncValueWidget<List<Study>>(
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  value: state.displayedStudies(
-                    snapshot.data!.preferences.pinnedStudies,
-                    state.query,
-                  ),
-                  data: (visibleStudies) => StudiesTable(
-                    studies: visibleStudies,
-                    pinnedStudies: snapshot.data!.preferences.pinnedStudies,
-                    dashboardController: ref.watch(
-                      dashboardControllerProvider.notifier,
-                    ),
-                    onSelect: controller.onSelectStudy,
-                    getActions: controller.availableActions,
-                    emptyWidget:
-                        (widget.filter == null ||
-                            widget.filter == StudiesFilter.owned)
-                        ? (state.query.isNotEmpty)
-                              ? Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
-                                    icon: Icons.content_paste_search_rounded,
-                                    title: tr.studies_not_found,
-                                    description: tr.modify_query,
-                                  ),
-                                )
-                              : Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
-                                    icon: Icons.content_paste_search_rounded,
-                                    title: tr.studies_empty,
-                                    description: tr.studies_empty_description,
-                                    // "...or create a new draft copy from an already published study!",
-                                    /* button: PrimaryButton(text: "From template",); */
-                                  ),
-                                )
-                        : const SizedBox.shrink(),
-                  ),
-                );
-              }
-              return const Center(child: CircularProgressIndicator());
-            },
+                FutureBuilder<StudyUUser>(
+                  future: ref.read(userRepositoryProvider).fetchUser(),
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      return AsyncValueWidget<List<Study>>(
+                        loading: () =>
+                            const Center(child: CircularProgressIndicator()),
+                        value: state.displayedStudies(
+                          snapshot.data!.preferences.pinnedStudies,
+                          state.query,
+                        ),
+                        data: (visibleStudies) {
+                          final selectedCount = state.selectedStudyIds.length;
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 12.0),
+                                child: Row(
+                                  children: [
+                                    Text(
+                                      '$selectedCount Studies selected.',
+                                      style: theme.textTheme.bodyMedium
+                                          ?.copyWith(
+                                            color: theme
+                                                .colorScheme
+                                                .onSurfaceVariant,
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                    ),
+                                    if (selectedCount > 0) ...[
+                                      const SizedBox(width: 12),
+                                      MenuAnchor(
+                                        builder:
+                                            (context, menuController, child) {
+                                              return OutlinedButton.icon(
+                                                onPressed:
+                                                    state.isBulkActionInProgress
+                                                    ? null
+                                                    : () {
+                                                        if (
+                                                            menuController
+                                                                .isOpen) {
+                                                          menuController.close();
+                                                        } else {
+                                                          menuController.open();
+                                                        }
+                                                      },
+                                                icon: state
+                                                        .isBulkActionInProgress
+                                                    ? const SizedBox(
+                                                        width: 16,
+                                                        height: 16,
+                                                        child:
+                                                            CircularProgressIndicator(
+                                                              strokeWidth: 2,
+                                                            ),
+                                                      )
+                                                    : const Icon(
+                                                        Icons.checklist_rounded,
+                                                      ),
+                                                label: Text(
+                                                  state.isBulkActionInProgress
+                                                      ? 'Working...'
+                                                      : 'Bulk actions',
+                                                ),
+                                              );
+                                            },
+                                        menuChildren: [
+                                          MenuItemButton(
+                                            leadingIcon: const Icon(
+                                              Icons.download_rounded,
+                                            ),
+                                            onPressed:
+                                                controller.exportSelectedStudies,
+                                            child: const Text(
+                                              'Export selected',
+                                            ),
+                                          ),
+                                          MenuItemButton(
+                                            leadingIcon: const Icon(
+                                              Icons.file_copy_rounded,
+                                            ),
+                                            onPressed: controller
+                                                .confirmDuplicateSelectedStudies,
+                                            child: const Text(
+                                              'Duplicate selected',
+                                            ),
+                                          ),
+                                          MenuItemButton(
+                                            leadingIcon: Icon(
+                                              Icons.delete_rounded,
+                                              color: theme.colorScheme.error,
+                                            ),
+                                            onPressed: controller
+                                                .confirmDeleteSelectedStudies,
+                                            child: Text(
+                                              'Delete selected',
+                                              style: TextStyle(
+                                                color: theme.colorScheme.error,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                              StudiesTable(
+                                studies: visibleStudies,
+                                pinnedStudies:
+                                    snapshot.data!.preferences.pinnedStudies,
+                                selectedStudyIds: state.selectedStudyIds,
+                                dashboardController: ref.watch(
+                                  dashboardControllerProvider.notifier,
+                                ),
+                                onSelectionChanged: (study) =>
+                                    controller.toggleStudySelection(study.id),
+                                onSelectAllChanged: () => controller
+                                    .toggleSelectAllVisibleStudies(
+                                      visibleStudies,
+                                    ),
+                                onSelect: controller.onSelectStudy,
+                                getActions: controller.availableActions,
+                                emptyWidget:
+                                    (widget.filter == null ||
+                                        widget.filter == StudiesFilter.owned)
+                                    ? (state.query.isNotEmpty)
+                                          ? Padding(
+                                              padding: const EdgeInsets.only(
+                                                top: 24.0,
+                                              ),
+                                              child: EmptyBody(
+                                                icon: Icons
+                                                    .content_paste_search_rounded,
+                                                title: tr.studies_not_found,
+                                                description: tr.modify_query,
+                                              ),
+                                            )
+                                          : Padding(
+                                              padding: const EdgeInsets.only(
+                                                top: 24.0,
+                                              ),
+                                              child: EmptyBody(
+                                                icon: Icons
+                                                    .content_paste_search_rounded,
+                                                title: tr.studies_empty,
+                                                description: tr
+                                                    .studies_empty_description,
+                                                /* button: PrimaryButton(text: "From template",); */
+                                              ),
+                                            )
+                                    : const SizedBox.shrink(),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    }
+                    return const Center(child: CircularProgressIndicator());
+                  },
+                ),
+              ],
+            ),
           ),
+          if (state.isBulkActionInProgress)
+            Positioned.fill(
+              child: ColoredBox(
+                color: theme.colorScheme.scrim.withValues(alpha: 0.08),
+                child: Center(
+                  child: Card(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 16,
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                          const SizedBox(width: 12),
+                          Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Bulk action in progress...',
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                'Completed ${state.bulkActionCompletedCount} of ${state.bulkActionTotalCount}',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/designer_v2/lib/features/dashboard/dashboard_state.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_state.dart
@@ -18,6 +18,10 @@ class DashboardState extends Equatable {
     this.studiesFilter = defaultFilter,
     this.activeFilter,
     this.query = '',
+    this.selectedStudyIds = const {},
+    this.isBulkActionInProgress = false,
+    this.bulkActionCompletedCount = 0,
+    this.bulkActionTotalCount = 0,
     this.sortByColumn = StudiesTableColumn.title,
     this.sortAscending = true,
     this.savedFilters = const [],
@@ -56,6 +60,14 @@ class DashboardState extends Equatable {
   final User currentUser;
 
   final String query;
+
+  final Set<String> selectedStudyIds;
+
+  final bool isBulkActionInProgress;
+
+  final int bulkActionCompletedCount;
+
+  final int bulkActionTotalCount;
 
   /// Search controller for managing search functionality
   final SearchController searchController;
@@ -115,6 +127,18 @@ class DashboardState extends Equatable {
   }) {
     final sortedStudies = studiesToSort ?? studies.value!;
     switch (sortByColumn) {
+      case StudiesTableColumn.selection:
+        break;
+      case StudiesTableColumn.serial:
+        if (!sortAscending) {
+          sortedStudies.sort(
+            (study, other) => other.createdAt!.compareTo(study.createdAt!),
+          );
+        } else {
+          sortedStudies.sort(
+            (study, other) => study.createdAt!.compareTo(other.createdAt!),
+          );
+        }
       case StudiesTableColumn.title:
         if (sortAscending) {
           sortedStudies.sort(
@@ -220,6 +244,10 @@ class DashboardState extends Equatable {
     List<SavedFilter> Function()? savedFilters,
     User Function()? currentUser,
     String? query,
+    Set<String>? selectedStudyIds,
+    bool? isBulkActionInProgress,
+    int? bulkActionCompletedCount,
+    int? bulkActionTotalCount,
     StudiesTableColumn? sortByColumn,
     bool? sortAscending,
     SearchController? searchController,
@@ -234,6 +262,12 @@ class DashboardState extends Equatable {
       savedFilters: savedFilters != null ? savedFilters() : this.savedFilters,
       currentUser: currentUser != null ? currentUser() : this.currentUser,
       query: query ?? this.query,
+      selectedStudyIds: selectedStudyIds ?? this.selectedStudyIds,
+      isBulkActionInProgress:
+          isBulkActionInProgress ?? this.isBulkActionInProgress,
+      bulkActionCompletedCount:
+          bulkActionCompletedCount ?? this.bulkActionCompletedCount,
+      bulkActionTotalCount: bulkActionTotalCount ?? this.bulkActionTotalCount,
       sortByColumn: sortByColumn ?? this.sortByColumn,
       sortAscending: sortAscending ?? this.sortAscending,
       searchController: searchController ?? this.searchController,
@@ -252,6 +286,10 @@ class DashboardState extends Equatable {
     activeFilter,
     savedFilters,
     query,
+    selectedStudyIds,
+    isBulkActionInProgress,
+    bulkActionCompletedCount,
+    bulkActionTotalCount,
     sortByColumn,
     sortAscending,
     selectedSavedFilterId,

--- a/designer_v2/lib/features/dashboard/studies_table.dart
+++ b/designer_v2/lib/features/dashboard/studies_table.dart
@@ -8,8 +8,11 @@ import 'package:studyu_designer_v2/features/dashboard/dashboard_controller.dart'
 import 'package:studyu_designer_v2/features/dashboard/studies_table_column_header.dart';
 import 'package:studyu_designer_v2/features/dashboard/studies_table_item.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/localization/string_hardcoded.dart';
 
 enum StudiesTableColumn {
+  selection,
+  serial,
   pin,
   title,
   status,
@@ -51,6 +54,9 @@ class StudiesTable extends StatelessWidget {
     required this.emptyWidget,
     required this.pinnedStudies,
     required this.dashboardController,
+    required this.selectedStudyIds,
+    required this.onSelectionChanged,
+    required this.onSelectAllChanged,
     this.itemHeight = 60.0,
     this.itemPadding = 10.0,
     this.rowSpacing = 9.0,
@@ -74,11 +80,21 @@ class StudiesTable extends StatelessWidget {
   final Widget emptyWidget;
   final Iterable<String> pinnedStudies;
   final DashboardController dashboardController;
+  final Set<String> selectedStudyIds;
+  final ValueChanged<Study> onSelectionChanged;
+  final VoidCallback onSelectAllChanged;
 
   @override
   Widget build(BuildContext context) {
     if (studies.isEmpty) {
       return emptyWidget;
+    }
+
+    final serialNumberByStudyId = <String, int>{};
+    final studiesBySerial = [...studies]
+      ..sort((study, other) => study.createdAt!.compareTo(other.createdAt!));
+    for (int index = 0; index < studiesBySerial.length; index++) {
+      serialNumberByStudyId[studiesBySerial[index].id] = index + 1;
     }
 
     return LayoutBuilder(
@@ -126,6 +142,12 @@ class StudiesTable extends StatelessWidget {
 
         // Set column definitions
         final columnDefinitionsMap = {
+          StudiesTableColumn.selection: StudiesTableColumnSize.fixedWidth(
+            itemHeight,
+          ),
+          StudiesTableColumn.serial: StudiesTableColumnSize.fixedWidth(
+            itemHeight,
+          ),
           StudiesTableColumn.pin: StudiesTableColumnSize.fixedWidth(itemHeight),
           StudiesTableColumn.title: StudiesTableColumnSize.flexWidth(32),
           StudiesTableColumn.status: StudiesTableColumnSize.fixedWidth(
@@ -158,78 +180,20 @@ class StudiesTable extends StatelessWidget {
               height: itemHeight,
               child: Row(
                 children: [
-                  columnDefinitions[0].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[0].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[0].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[1].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[1].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[1].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[2].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[2].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[2].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[3].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[3].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[3].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[4].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[4].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[4].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[5].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[5].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[5].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[6].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[6].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[6].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[7].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[7].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[7].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
-                  columnDefinitions[8].value.createContainer(
-                    child: _buildColumnHeader(columnDefinitions[8].key),
-                  ),
-                  SizedBox(
-                    width: columnDefinitions[8].value.collapsed
-                        ? 0
-                        : columnSpacing,
-                  ),
+                  for (int index = 0; index < columnDefinitions.length; index++)
+                    ...[
+                      columnDefinitions[index].value.createContainer(
+                        child: _buildColumnHeader(
+                          context,
+                          columnDefinitions[index].key,
+                        ),
+                      ),
+                      SizedBox(
+                        width: columnDefinitions[index].value.collapsed
+                            ? 0
+                            : columnSpacing,
+                      ),
+                    ],
                 ],
               ),
             ),
@@ -242,12 +206,15 @@ class StudiesTable extends StatelessWidget {
                 final item = studies[index];
                 return StudiesTableItem(
                   study: item,
+                  serialNumber: serialNumberByStudyId[item.id] ?? (index + 1),
+                  isSelected: selectedStudyIds.contains(item.id),
                   columnSizes: columnDefinitionsMap.values.toList(),
                   actions: getActions(item),
                   isPinned: pinnedStudies.contains(item.id),
                   itemHeight: itemHeight,
                   rowSpacing: rowSpacing,
                   columnSpacing: columnSpacing,
+                  onSelectionChanged: (_) => onSelectionChanged(item),
                   onPinnedChanged: (study, pinned) {
                     pinnedStudies.contains(item.id)
                         ? dashboardController.pinOffStudy(item.id)
@@ -263,11 +230,35 @@ class StudiesTable extends StatelessWidget {
     );
   }
 
-  Widget _buildColumnHeader(StudiesTableColumn column) {
+  Widget _buildColumnHeader(BuildContext context, StudiesTableColumn column) {
+    if (column == StudiesTableColumn.selection) {
+      final visibleIds = studies.map((study) => study.id).toSet();
+      final selectedVisibleCount = visibleIds
+          .where(selectedStudyIds.contains)
+          .length;
+      final allVisibleSelected =
+          visibleIds.isNotEmpty && selectedVisibleCount == visibleIds.length;
+      final someVisibleSelected =
+          selectedVisibleCount > 0 && selectedVisibleCount < visibleIds.length;
+
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: Checkbox(
+          value: allVisibleSelected ? true : (someVisibleSelected ? null : false),
+          tristate: true,
+          onChanged: (_) => onSelectAllChanged(),
+        ),
+      );
+    }
+
     final String title;
     switch (column) {
       case StudiesTableColumn.title:
         title = tr.studies_list_header_title;
+      case StudiesTableColumn.selection:
+        title = '';
+      case StudiesTableColumn.serial:
+        title = 'Serial'.hardcoded;
       case StudiesTableColumn.status:
         title = tr.studies_list_header_status;
       case StudiesTableColumn.participation:
@@ -281,13 +272,15 @@ class StudiesTable extends StatelessWidget {
       case StudiesTableColumn.completed:
         title = tr.studies_list_header_participants_completed;
       case StudiesTableColumn.pin:
-      case StudiesTableColumn.action:
         title = '';
+      case StudiesTableColumn.action:
+        title = 'Actions';
     }
 
     final sortAscending = dashboardController.isSortAscending;
     final sortable =
-        !(column == StudiesTableColumn.pin ||
+        !(column == StudiesTableColumn.selection ||
+            column == StudiesTableColumn.pin ||
             column == StudiesTableColumn.action);
     final sortingActive = dashboardController.isSortingActiveForColumn(column);
 
@@ -296,6 +289,11 @@ class StudiesTable extends StatelessWidget {
       sortable: sortable,
       sortingActive: sortingActive,
       sortAscending: sortAscending(),
+      alignRight:
+          column == StudiesTableColumn.serial ||
+          column == StudiesTableColumn.enrolled ||
+          column == StudiesTableColumn.active ||
+          column == StudiesTableColumn.completed,
       center:
           column != StudiesTableColumn.title &&
           column != StudiesTableColumn.pin,

--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -9,6 +9,7 @@ class StudiesTableColumnHeader extends StatefulWidget {
   final bool sortingActive;
   final void Function()? onSort;
   final bool center;
+  final bool alignRight;
 
   const StudiesTableColumnHeader(
     this.title, {
@@ -18,6 +19,7 @@ class StudiesTableColumnHeader extends StatefulWidget {
     required this.sortAscending,
     this.onSort,
     this.center = false,
+    this.alignRight = false,
   });
 
   @override
@@ -35,9 +37,11 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
     return MouseEventsRegion(
       builder: (context, state) {
         return Row(
-          mainAxisAlignment: widget.center
-              ? MainAxisAlignment.center
-              : MainAxisAlignment.start,
+          mainAxisAlignment: widget.alignRight
+              ? MainAxisAlignment.end
+              : (widget.center
+                    ? MainAxisAlignment.center
+                    : MainAxisAlignment.start),
           children: [
             Flexible(
               child: Text(
@@ -45,9 +49,13 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
                 maxLines: 1,
                 overflow: TextOverflow.fade,
                 softWrap: false,
-                textAlign: widget.center ? TextAlign.center : TextAlign.start,
-                style: theme.textTheme.bodySmall!.copyWith(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+                textAlign: widget.alignRight
+                    ? TextAlign.end
+                    : (widget.center ? TextAlign.center : TextAlign.start),
+                style: theme.textTheme.labelMedium!.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.88),
+                  letterSpacing: 0.15,
                 ),
               ),
             ),

--- a/designer_v2/lib/features/dashboard/studies_table_item.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_item.dart
@@ -12,6 +12,8 @@ import 'package:studyu_designer_v2/utils/model_action.dart';
 
 class StudiesTableItem extends StatefulWidget {
   final Study study;
+  final int serialNumber;
+  final bool isSelected;
   final double itemHeight;
   final double itemPadding;
   final double rowSpacing;
@@ -19,22 +21,26 @@ class StudiesTableItem extends StatefulWidget {
   final List<ModelAction> actions;
   final List<StudiesTableColumnSize> columnSizes;
   final bool isPinned;
+  final ValueChanged<bool>? onSelectionChanged;
   final void Function(Study, bool)? onPinnedChanged;
   final void Function(Study)? onTap;
 
   const StudiesTableItem({
     super.key,
     required this.study,
+    required this.serialNumber,
+    required this.isSelected,
     required this.actions,
     required this.columnSizes,
     required this.isPinned,
+    this.onSelectionChanged,
     this.onPinnedChanged,
     this.onTap,
     this.itemHeight = 60.0,
     this.itemPadding = 10.0,
     this.rowSpacing = 9.0,
     this.columnSpacing = 10.0,
-  }) : assert(columnSizes.length == 9);
+  }) : assert(columnSizes.length == 11);
 
   @override
   State<StudiesTableItem> createState() => _StudiesTableItemState();
@@ -70,14 +76,18 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
       child: LayoutBuilder(
         builder: (_, constraints) {
           return Material(
-            color: theme.colorScheme.onPrimary,
+            color: widget.isSelected
+                ? theme.colorScheme.primaryContainer.withValues(alpha: 0.18)
+                : theme.colorScheme.onPrimary,
             shape: RoundedRectangleBorder(
               borderRadius: const BorderRadius.all(Radius.circular(4)),
               side: BorderSide(
-                color: theme.colorScheme.primaryContainer.withValues(
-                  alpha: 0.9,
-                ),
-                width: isHovering ? 1.5 : 0.75,
+                color: widget.isSelected
+                    ? theme.colorScheme.primary.withValues(alpha: 0.55)
+                    : theme.colorScheme.primaryContainer.withValues(
+                        alpha: 0.9,
+                      ),
+                width: widget.isSelected ? 1.25 : (isHovering ? 1.5 : 0.75),
               ),
             ),
             child: InkWell(
@@ -94,6 +104,38 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                 child: Row(
                   children: [
                     widget.columnSizes[0].createContainer(
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Checkbox(
+                          value: widget.isSelected,
+                          onChanged: (selected) {
+                            if (selected != null) {
+                              widget.onSelectionChanged?.call(selected);
+                            }
+                          },
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[1].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[1].createContainer(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          widget.serialNumber.toString(),
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[0].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[2].createContainer(
                       height: widget.itemHeight,
                       child: MouseEventsRegion(
                         onTap: () => widget.onPinnedChanged?.call(
@@ -108,39 +150,15 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                       ),
                     ),
                     SizedBox(
-                      width: widget.columnSizes[0].collapsed
-                          ? 0
-                          : widget.columnSpacing,
-                    ),
-                    widget.columnSizes[1].createContainer(
-                      child: Text(
-                        widget.study.title ?? '[Missing study title]',
-                        maxLines: 3,
-                        overflow: TextOverflow.fade,
-                      ),
-                    ),
-                    SizedBox(
-                      width: widget.columnSizes[1].collapsed
-                          ? 0
-                          : widget.columnSpacing,
-                    ),
-                    widget.columnSizes[2].createContainer(
-                      child: Center(
-                        child: StudyStatusBadge(
-                          status: widget.study.status,
-                          showPrefixIcon: false,
-                          showTooltip: false,
-                        ),
-                      ),
-                    ),
-                    SizedBox(
                       width: widget.columnSizes[2].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[3].createContainer(
-                      child: StudyParticipationBadge(
-                        participation: widget.study.participation,
+                      child: Text(
+                        widget.study.title ?? '[Missing study title]',
+                        maxLines: 3,
+                        overflow: TextOverflow.fade,
                       ),
                     ),
                     SizedBox(
@@ -150,11 +168,10 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     ),
                     widget.columnSizes[4].createContainer(
                       child: Center(
-                        child: Text(
-                          widget.study.createdAt?.toTimeAgoString() ?? '',
-                          maxLines: 3,
-                          overflow: TextOverflow.fade,
-                          textAlign: TextAlign.center,
+                        child: StudyStatusBadge(
+                          status: widget.study.status,
+                          showPrefixIcon: false,
+                          showTooltip: false,
                         ),
                       ),
                     ),
@@ -164,13 +181,8 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[5].createContainer(
-                      child: Center(
-                        child: Text(
-                          widget.study.participantCount.toString(),
-                          style: mutedTextStyleIfZero(
-                            widget.study.participantCount,
-                          ),
-                        ),
+                      child: StudyParticipationBadge(
+                        participation: widget.study.participation,
                       ),
                     ),
                     SizedBox(
@@ -181,10 +193,10 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     widget.columnSizes[6].createContainer(
                       child: Center(
                         child: Text(
-                          widget.study.activeSubjectCount.toString(),
-                          style: mutedTextStyleIfZero(
-                            widget.study.activeSubjectCount,
-                          ),
+                          widget.study.createdAt?.toTimeAgoString() ?? '',
+                          maxLines: 3,
+                          overflow: TextOverflow.fade,
+                          textAlign: TextAlign.center,
                         ),
                       ),
                     ),
@@ -194,10 +206,13 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[7].createContainer(
-                      child: Center(
+                      child: Align(
+                        alignment: Alignment.centerRight,
                         child: Text(
-                          widget.study.endedCount.toString(),
-                          style: mutedTextStyleIfZero(widget.study.endedCount),
+                          widget.study.participantCount.toString(),
+                          style: mutedTextStyleIfZero(
+                            widget.study.participantCount,
+                          ),
                         ),
                       ),
                     ),
@@ -207,10 +222,40 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                           : widget.columnSpacing,
                     ),
                     widget.columnSizes[8].createContainer(
-                      child: _buildActionMenu(context, widget.actions),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          widget.study.activeSubjectCount.toString(),
+                          style: mutedTextStyleIfZero(
+                            widget.study.activeSubjectCount,
+                          ),
+                        ),
+                      ),
                     ),
                     SizedBox(
                       width: widget.columnSizes[8].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[9].createContainer(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          widget.study.endedCount.toString(),
+                          style: mutedTextStyleIfZero(widget.study.endedCount),
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[9].collapsed
+                          ? 0
+                          : widget.columnSpacing,
+                    ),
+                    widget.columnSizes[10].createContainer(
+                      child: _buildActionMenu(context, widget.actions),
+                    ),
+                    SizedBox(
+                      width: widget.columnSizes[10].collapsed
                           ? 0
                           : widget.columnSpacing,
                     ),

--- a/designer_v2/lib/repositories/api_client.dart
+++ b/designer_v2/lib/repositories/api_client.dart
@@ -55,7 +55,23 @@ abstract class StudyUApi {
 typedef SupabaseQueryExceptionHandler = void Function(SupabaseQueryError error);
 
 /// Base class for domain-specific exceptions
-class APIException implements Exception {}
+class APIException implements Exception {
+  APIException({this.statusCode, this.message, this.details});
+
+  final String? statusCode;
+  final String? message;
+  final Object? details;
+
+  @override
+  String toString() {
+    final parts = <String>[
+      if (statusCode != null) 'statusCode=$statusCode',
+      if (message != null && message!.isNotEmpty) 'message=$message',
+      if (details != null) 'details=$details',
+    ];
+    return parts.isEmpty ? 'APIException' : 'APIException(${parts.join(', ')})';
+  }
+}
 
 class StudyNotFoundException extends APIException {}
 
@@ -204,9 +220,8 @@ class StudyUApiClient extends SupabaseClientDependant
   @override
   Future<void> deleteStudy(Study study) async {
     await _testDelay();
-    // Delegate to [SupabaseObjectMethods]
-    // TODO: proper error handling here (encountered so far: 409, 406)
-    await study.delete();
+    // Delegate to [SupabaseObjectMethods] but preserve backend error details.
+    await _awaitGuarded<Study>(study.delete());
   }
 
   @override
@@ -352,13 +367,29 @@ class StudyUApiClient extends SupabaseClientDependant
       debugLog(error.statusCode.toString());
       debugLog(error.details.toString());
       debugLog(error.message);
+      return APIException(
+        statusCode: error.statusCode,
+        message: error.message,
+        details: error.details,
+      );
+    } else if (error != null && error is PostgrestException) {
+      debugLog("Postgrest Exception encountered");
+      debugLog(error.code.toString());
+      debugLog(error.details.toString());
+      debugLog(error.message);
+      return APIException(
+        statusCode: error.code,
+        message: error.message,
+        details: error.details,
+      );
     } else if (error != null) {
       debugLog("Unknown exception encountered");
       debugLog(error.toString());
+      return APIException(message: error.toString());
     } else {
       debugLog("Unknown exception encountered. No error provided.");
+      return APIException();
     }
-    return APIException();
   }
 
   Future<void> _testDelay() async {

--- a/designer_v2/lib/repositories/model_repository.dart
+++ b/designer_v2/lib/repositories/model_repository.dart
@@ -252,6 +252,7 @@ abstract class ModelRepository<T> extends IModelRepository<T> {
         get(modelId)?.markWithError(e);
         emitError(modelStreamControllers[modelId], e, stackTrace);
       },
+      rethrowErrors: true,
       runOptimistically: runOptimistically,
       completeFutureOptimistically: runOptimistically,
     );

--- a/designer_v2/lib/repositories/study_repository.dart
+++ b/designer_v2/lib/repositories/study_repository.dart
@@ -23,6 +23,8 @@ abstract class IStudyRepository implements ModelRepository<Study> {
   Future<void> launch(Study study);
   Future<void> deleteParticipants(Study study);
   Future<void> close(Study study);
+  Future<void> deletePersisted(ModelID studyId);
+  Future<void> duplicateAndSavePersisted(Study model);
   // Future<void> deleteProgress(Study study);
 }
 
@@ -116,6 +118,20 @@ class StudyRepository extends ModelRepository<Study>
       authRepository.currentUser!.id,
     );
     await save(duplicate);
+  }
+
+  @override
+  Future<void> duplicateAndSavePersisted(Study model) async {
+    final Study completeModel = await apiClient.fetchStudy(model.id);
+    final duplicate = completeModel.duplicateAsDraft(
+      authRepository.currentUser!.id,
+    );
+    await save(duplicate, runOptimistically: false);
+  }
+
+  @override
+  Future<void> deletePersisted(ModelID studyId) {
+    return delete(studyId, runOptimistically: false);
   }
 
   @override


### PR DESCRIPTION
## Summary
Adds bulk study actions to the dashboard and makes their execution more reliable and transparent.

## What changed
- Added row selection to the studies table, including select/deselect and select all.
- Added bulk actions for selected studies:
  - export
  - duplicate
  - delete
- Moved bulk actions into a single `Bulk actions` dropdown.
- Added loading and progress feedback during bulk operations.
- Disabled interaction while a bulk action is running.
- Improved bulk export feedback:
  - export only runs when triggered by the user
  - studies that cannot be exported are skipped
  - the UI reports which studies were skipped and why
- Improved bulk delete reliability:
  - wait for persisted backend completion
  - refresh study data after delete/duplicate
  - only report deletion as successful when backend state confirms it
- Improved delete failure messaging for backend conflicts, including user-friendly handling for studies that still have invite codes linked to them.

## Technical changes
- Updated dashboard selection and bulk-action state handling.
- Added progress counters for long-running bulk operations.
- Updated repository delete/duplicate paths to support non-optimistic persisted operations for bulk flows.
- Preserved backend error details from API delete calls so the UI can show more meaningful failure reasons.

## Files touched
- `designer_v2/lib/features/dashboard/dashboard_controller.dart`
- `designer_v2/lib/features/dashboard/dashboard_page.dart`
- `designer_v2/lib/features/dashboard/dashboard_state.dart`
- `designer_v2/lib/features/dashboard/studies_table.dart`
- `designer_v2/lib/features/dashboard/studies_table_column_header.dart`
- `designer_v2/lib/features/dashboard/studies_table_item.dart`
- `designer_v2/lib/features/analyze/study_export_zip.dart`
- `designer_v2/lib/repositories/api_client.dart`
- `designer_v2/lib/repositories/model_repository.dart`
- `designer_v2/lib/repositories/study_repository.dart`

## Validation
- Bulk action controls appear only when studies are selected.
- Bulk actions run with a visible in-progress state and progress count.
- Export reports skipped studies with reasons instead of silently failing.
- Delete no longer claims success based only on local UI state.
- Dashboard data is refreshed after delete and duplicate operations.
