### PR TITLE
fix(dashboard): restore studies table pinning

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_controller.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_controller.dart
@@ -71,6 +71,7 @@ class DashboardController extends _$DashboardController
       state = state.copyWith(
         savedFilters: () => savedFilters,
         activeFilter: () => active.filterGroup,
+        pinnedStudies: () => _userRepository.user.preferences.pinnedStudies,
         selectedSavedFilterId: () => active.presetId,
       );
     } catch (e) {
@@ -162,11 +163,17 @@ class DashboardController extends _$DashboardController
 
   Future<void> pinStudy(String modelId) async {
     await _userRepository.updatePreferences(PreferenceAction.pin, modelId);
+    state = state.copyWith(
+      pinnedStudies: () => _userRepository.user.preferences.pinnedStudies,
+    );
     sortStudies();
   }
 
   Future<void> pinOffStudy(String modelId) async {
     await _userRepository.updatePreferences(PreferenceAction.pinOff, modelId);
+    state = state.copyWith(
+      pinnedStudies: () => _userRepository.user.preferences.pinnedStudies,
+    );
     sortStudies();
   }
 
@@ -182,9 +189,7 @@ class DashboardController extends _$DashboardController
   }
 
   Future<void> sortStudies() async {
-    final studies = state.sort(
-      pinnedStudies: _userRepository.user.preferences.pinnedStudies,
-    );
+    final studies = state.sort(pinnedStudies: state.pinnedStudies);
     state = state.copyWith(studies: () => AsyncValue.data(studies));
   }
 

--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -15,7 +15,6 @@ import 'package:studyu_designer_v2/features/dashboard/studies_filter/filter_type
 import 'package:studyu_designer_v2/features/dashboard/studies_table.dart';
 import 'package:studyu_designer_v2/localization/app_localizations.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
-import 'package:studyu_designer_v2/repositories/user_repository.dart';
 import 'package:studyu_designer_v2/utils/comparator_utils.dart';
 import 'package:studyu_designer_v2/utils/performance.dart';
 
@@ -525,53 +524,41 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
             ),
           ],
           const SizedBox(height: 24.0), // spacing between body elements
-          FutureBuilder<StudyUUser>(
-            future: ref.read(userRepositoryProvider).fetchUser(),
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return AsyncValueWidget<List<Study>>(
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  value: state.displayedStudies(
-                    snapshot.data!.preferences.pinnedStudies,
-                    state.query,
-                  ),
-                  data: (visibleStudies) => StudiesTable(
-                    studies: visibleStudies,
-                    pinnedStudies: snapshot.data!.preferences.pinnedStudies,
-                    dashboardController: ref.watch(
-                      dashboardControllerProvider.notifier,
-                    ),
-                    onSelect: controller.onSelectStudy,
-                    getActions: controller.availableActions,
-                    emptyWidget:
-                        (widget.filter == null ||
-                            widget.filter == StudiesFilter.owned)
-                        ? (state.query.isNotEmpty)
-                              ? Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
-                                    icon: Icons.content_paste_search_rounded,
-                                    title: tr.studies_not_found,
-                                    description: tr.modify_query,
-                                  ),
-                                )
-                              : Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
-                                    icon: Icons.content_paste_search_rounded,
-                                    title: tr.studies_empty,
-                                    description: tr.studies_empty_description,
-                                    // "...or create a new draft copy from an already published study!",
-                                    /* button: PrimaryButton(text: "From template",); */
-                                  ),
-                                )
-                        : const SizedBox.shrink(),
-                  ),
-                );
-              }
-              return const Center(child: CircularProgressIndicator());
-            },
+          AsyncValueWidget<List<Study>>(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            value: state.displayedStudies(state.pinnedStudies, state.query),
+            data: (visibleStudies) => StudiesTable(
+              studies: visibleStudies,
+              pinnedStudies: state.pinnedStudies,
+              dashboardController: ref.watch(
+                dashboardControllerProvider.notifier,
+              ),
+              onSelect: controller.onSelectStudy,
+              getActions: controller.availableActions,
+              emptyWidget:
+                  (widget.filter == null ||
+                      widget.filter == StudiesFilter.owned)
+                  ? (state.query.isNotEmpty)
+                        ? Padding(
+                            padding: const EdgeInsets.only(top: 24.0),
+                            child: EmptyBody(
+                              icon: Icons.content_paste_search_rounded,
+                              title: tr.studies_not_found,
+                              description: tr.modify_query,
+                            ),
+                          )
+                        : Padding(
+                            padding: const EdgeInsets.only(top: 24.0),
+                            child: EmptyBody(
+                              icon: Icons.content_paste_search_rounded,
+                              title: tr.studies_empty,
+                              description: tr.studies_empty_description,
+                              // "...or create a new draft copy from an already published study!",
+                              /* button: PrimaryButton(text: "From template",); */
+                            ),
+                          )
+                  : const SizedBox.shrink(),
+            ),
           ),
         ],
       ),

--- a/designer_v2/lib/features/dashboard/dashboard_state.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_state.dart
@@ -21,6 +21,7 @@ class DashboardState extends Equatable {
     this.sortByColumn = StudiesTableColumn.title,
     this.sortAscending = true,
     this.savedFilters = const [],
+    this.pinnedStudies = const {},
     this.selectedSavedFilterId,
     required this.currentUser,
     required this.searchController,
@@ -43,6 +44,9 @@ class DashboardState extends Equatable {
 
   /// List of saved custom filters
   final List<SavedFilter> savedFilters;
+
+  /// Pinned study ids from the current user's preferences.
+  final Set<String> pinnedStudies;
 
   /// Currently selected sort column to be applied to the list of studies
   /// in order to determine the [displayedStudies]
@@ -113,7 +117,7 @@ class DashboardState extends Equatable {
     required Set<String> pinnedStudies,
     List<Study>? studiesToSort,
   }) {
-    final sortedStudies = studiesToSort ?? studies.value!;
+    final sortedStudies = List<Study>.from(studiesToSort ?? studies.value!);
     switch (sortByColumn) {
       case StudiesTableColumn.title:
         if (sortAscending) {
@@ -218,6 +222,7 @@ class DashboardState extends Equatable {
     StudiesFilter? Function()? studiesFilter,
     FilterGroup? Function()? activeFilter,
     List<SavedFilter> Function()? savedFilters,
+    Set<String> Function()? pinnedStudies,
     User Function()? currentUser,
     String? query,
     StudiesTableColumn? sortByColumn,
@@ -232,6 +237,7 @@ class DashboardState extends Equatable {
           : this.studiesFilter,
       activeFilter: activeFilter != null ? activeFilter() : this.activeFilter,
       savedFilters: savedFilters != null ? savedFilters() : this.savedFilters,
+      pinnedStudies: pinnedStudies != null ? pinnedStudies() : this.pinnedStudies,
       currentUser: currentUser != null ? currentUser() : this.currentUser,
       query: query ?? this.query,
       sortByColumn: sortByColumn ?? this.sortByColumn,
@@ -251,6 +257,7 @@ class DashboardState extends Equatable {
     studiesFilter,
     activeFilter,
     savedFilters,
+    pinnedStudies,
     query,
     sortByColumn,
     sortAscending,

--- a/designer_v2/lib/features/dashboard/studies_table.dart
+++ b/designer_v2/lib/features/dashboard/studies_table.dart
@@ -251,9 +251,9 @@ class StudiesTable extends StatelessWidget {
                   rowSpacing: rowSpacing,
                   columnSpacing: columnSpacing,
                   onPinnedChanged: (study, pinned) {
-                    pinnedStudies.contains(item.id)
-                        ? dashboardController.pinOffStudy(item.id)
-                        : dashboardController.pinStudy(item.id);
+                    pinned
+                        ? dashboardController.pinStudy(study.id)
+                        : dashboardController.pinOffStudy(study.id);
                   },
                   onTap: (study) => onSelect.call(study),
                 );


### PR DESCRIPTION
Move pinned study state into the dashboard controller so table pin/unpin updates reactively, and use the current toggle state when applying pin actions.