### PR TITLE
fix(measurements): persist new survey questions

### DIFF
--- a/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
@@ -194,6 +194,8 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
     MeasurementSurveyFormViewModel formViewModel,
     FormMode prevFormMode,
   ) async {
+    final isNewMeasurement = prevFormMode == FormMode.create;
+
     if (prevFormMode == FormMode.create) {
       // Commit the managed viewmodel that was eagerly added in [provide]
       surveyMeasurementFormViewModels.commit(formViewModel);
@@ -201,5 +203,14 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
       // nothing to do here
     }
     await super.save();
+
+    if (isNewMeasurement) {
+      router.dispatch(
+        RoutingIntents.studyEditMeasurement(
+          study.id,
+          formViewModel.measurementId,
+        ),
+      );
+    }
   }
 }

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
@@ -30,7 +30,10 @@ class MeasurementSurveyFormViewModel
     super.delegate,
     super.formData,
     super.validationSet = StudyFormValidationSet.draft,
-  });
+  }) {
+    // Persist survey changes when managed questions are added, edited, or removed.
+    propagateOnSave = true;
+  }
 
   final Study study;
 

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
@@ -239,7 +239,7 @@ class ChoiceQuestionFormData extends QuestionFormData {
       answerOptions: [...answerOptions],
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -307,7 +307,7 @@ class BoolQuestionFormData extends QuestionFormData {
       questionInfoText: questionInfoText,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -374,7 +374,7 @@ class ImageQuestionFormData extends QuestionFormData {
       questionInfoText: questionInfoText,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -448,7 +448,7 @@ class AudioQuestionFormData extends QuestionFormData {
       conditional: conditional?.deepCopy(),
       maxRecordingDurationSeconds: maxRecordingDurationSeconds,
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -585,7 +585,7 @@ class ScaleQuestionFormData extends QuestionFormData {
       midValues: midValues,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -664,7 +664,7 @@ class FreeTextQuestionFormData extends QuestionFormData {
       textTypeExpression: textTypeExpression,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -733,7 +733,7 @@ class FitbitQuestionFormData extends QuestionFormData {
       types: types,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 
@@ -814,7 +814,7 @@ class PainQuestionFormData extends QuestionFormData {
       questionInfoText: questionInfoText,
       conditional: conditional?.deepCopy(),
     );
-    data.responseOptionsValidity = responseOptionsValidity;
+    data.responseOptionsValidity = {...responseOptionsValidity};
     return data;
   }
 


### PR DESCRIPTION
## What changed
Fixes the measurements survey editor so newly created questions are saved correctly and duplicated questions no longer fail.

## Why
Creating a question in a brand-new measurement could appear to succeed, but the question would not remain visible because the route stayed on `/measurements/new` and reopened a fresh staged survey after save. Duplicating a fresh question could also fail because `responseOptionsValidity` was read before it had been initialized.

## User impact
Users can now:
- save a question in a newly created measurement survey and see it remain in the list
- duplicate a newly created question without triggering a runtime error
- continue editing on the saved measurement route instead of being reset to an empty staged survey

## Root cause
There were two issues in the measurements flow:
- question form duplication assumed `responseOptionsValidity` had always been initialized
- question changes in measurement surveys needed to propagate up to the parent survey save, and new measurements needed to redirect from the temporary `new` route to the real measurement id after the first save

## Validation
- reproduced the failing create-and-duplicate flow from the measurements page
- fixed the runtime crash in question duplication
- wired question save propagation for measurement surveys
- redirected newly saved measurements to their persisted route
- did not run automated tests
