### PR TITLE
fix(db): add ON DELETE CASCADE to study FK constraints

### DIFF
--- a/database/migration/20260425_study_cascade_delete.sql
+++ b/database/migration/20260425_study_cascade_delete.sql
@@ -1,0 +1,24 @@
+--
+-- Add ON DELETE CASCADE to all FK constraints referencing study(id)
+-- so that deleting a study automatically removes all dependent records.
+--
+
+ALTER TABLE public.repo
+  DROP CONSTRAINT "repo_studyId_fkey",
+  ADD CONSTRAINT "repo_studyId_fkey"
+    FOREIGN KEY (study_id) REFERENCES public.study(id) ON DELETE CASCADE;
+
+ALTER TABLE public.study_fitbit_credentials
+  DROP CONSTRAINT "study_fitbit_credentials_studyId_fkey",
+  ADD CONSTRAINT "study_fitbit_credentials_studyId_fkey"
+    FOREIGN KEY (study_id) REFERENCES public.study(id) ON DELETE CASCADE;
+
+ALTER TABLE public.study_invite
+  DROP CONSTRAINT "study_invite_studyId_fkey",
+  ADD CONSTRAINT "study_invite_studyId_fkey"
+    FOREIGN KEY (study_id) REFERENCES public.study(id) ON DELETE CASCADE;
+
+ALTER TABLE public.study_subject
+  DROP CONSTRAINT "study_subject_studyId_fkey",
+  ADD CONSTRAINT "study_subject_studyId_fkey"
+    FOREIGN KEY (study_id) REFERENCES public.study(id) ON DELETE CASCADE;

--- a/database/studyu-schema.sql
+++ b/database/studyu-schema.sql
@@ -640,7 +640,7 @@ ALTER TABLE ONLY "public"."subject_progress"
 
 
 ALTER TABLE ONLY "public"."repo"
-    ADD CONSTRAINT "repo_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id");
+    ADD CONSTRAINT "repo_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id") ON DELETE CASCADE;
 
 
 
@@ -650,12 +650,12 @@ ALTER TABLE ONLY "public"."repo"
 
 
 ALTER TABLE ONLY "public"."study_fitbit_credentials"
-    ADD CONSTRAINT "study_fitbit_credentials_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id");
+    ADD CONSTRAINT "study_fitbit_credentials_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id") ON DELETE CASCADE;
 
 
 
 ALTER TABLE ONLY "public"."study_invite"
-    ADD CONSTRAINT "study_invite_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id");
+    ADD CONSTRAINT "study_invite_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id") ON DELETE CASCADE;
 
 
 
@@ -665,7 +665,7 @@ ALTER TABLE ONLY "public"."study_subject"
 
 
 ALTER TABLE ONLY "public"."study_subject"
-    ADD CONSTRAINT "study_subject_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id");
+    ADD CONSTRAINT "study_subject_studyId_fkey" FOREIGN KEY ("study_id") REFERENCES "public"."study"("id") ON DELETE CASCADE;
 
 
 


### PR DESCRIPTION
## Problem
Deleting a study from the backend threw a PostgrestException (23503 FK violation) when dependent records existed in `study_invite`, `study_subject`, `repo`, or `study_fitbit_credentials`. These four FK constraints referenced `study(id)` without `ON DELETE CASCADE`, blocking the delete entirely.

## Changes
- Added migration `database/migration/20260425_study_cascade_delete.sql` — drops and re-adds all four FK constraints with `ON DELETE CASCADE`
- Updated `database/studyu-schema.sql` to reflect the new constraint definitions

## Testing
- [ ] Run migration against Supabase instance and verify it applies cleanly
- [ ] Delete a study that has existing invites, subjects, repo entry, and Fitbit credentials — confirm it succeeds without FK error
- [ ] Verify dependent records are removed from all four tables after deletion
- [ ] No regressions in study creation or subject enrollment flows