### PR TITLE
fix(designer): normalize custom study sequence input

### DIFF
--- a/designer_v2/lib/features/design/interventions/study_schedule_form_controller_mixin.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_controller_mixin.dart
@@ -6,12 +6,14 @@ import 'package:studyu_designer_v2/features/design/study_form_validation.dart';
 import 'package:studyu_designer_v2/features/forms/form_validation.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/utils/input_formatter.dart';
 
 mixin StudyScheduleControls {
   static const defaultScheduleType = PhaseSequence.alternating;
   static const defaultScheduleTypeSequence = 'ABAB';
   static const defaultNumCycles = 2;
   static const defaultPeriodLength = 7;
+  static final RegExp customSequencePattern = RegExp(r'^[ABab]+$');
 
   final FormControl<PhaseSequence> sequenceTypeControl = FormControl(
     value: defaultScheduleType,
@@ -110,10 +112,15 @@ mixin StudyScheduleControls {
 
   FormControlValidation get customSequenceRequired => FormControlValidation(
     control: sequenceTypeCustomControl,
-    validators: [Validators.required],
+    validators: [
+      Validators.required,
+      Validators.pattern(customSequencePattern),
+    ],
     validationMessages: {
       ValidationMessage.required: (error) =>
           'Custom sequence needs to be specified.',
+      ValidationMessage.pattern: (error) =>
+          'Custom sequence can only contain A and B.',
     },
   );
 
@@ -128,7 +135,9 @@ mixin StudyScheduleControls {
   StudyScheduleFormData buildStudyScheduleFormData() {
     return StudyScheduleFormData(
       sequenceType: sequenceTypeControl.value!, // required
-      sequenceTypeCustom: sequenceTypeCustomControl.value!, // required
+      sequenceTypeCustom: normalizeStudySequenceInput(
+        sequenceTypeCustomControl.value!,
+      ), // required
       numCycles: numCyclesControl.value!, // required
       phaseDuration: phaseDurationControl.value!, // required
       includeBaseline: includeBaselineControl.value!, // required

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_controller_mixin.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_controller_mixin.dart
@@ -112,10 +112,7 @@ mixin StudyScheduleControls {
 
   FormControlValidation get customSequenceRequired => FormControlValidation(
     control: sequenceTypeCustomControl,
-    validators: [
-      Validators.required,
-      Validators.pattern(customSequencePattern),
-    ],
+    validators: [Validators.delegate(_validateCustomSequence)],
     validationMessages: {
       ValidationMessage.required: (error) =>
           'Custom sequence needs to be specified.',
@@ -123,6 +120,23 @@ mixin StudyScheduleControls {
           'Custom sequence can only contain A and B.',
     },
   );
+
+  Map<String, dynamic>? _validateCustomSequence(
+    AbstractControl<dynamic> control,
+  ) {
+    if (!isSequencingCustom()) return null;
+
+    final value = control.value as String?;
+    if (value == null || value.isEmpty) {
+      return {ValidationMessage.required: true};
+    }
+
+    if (!customSequencePattern.hasMatch(value)) {
+      return {ValidationMessage.pattern: true};
+    }
+
+    return null;
+  }
 
   void setStudyScheduleControlsFrom(StudyScheduleFormData data) {
     sequenceTypeControl.value = data.sequenceType;

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_data.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_data.dart
@@ -1,6 +1,7 @@
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/features/design/study_form_data.dart';
 import 'package:studyu_designer_v2/features/forms/form_data.dart';
+import 'package:studyu_designer_v2/utils/input_formatter.dart';
 
 class StudyScheduleFormData implements IStudyFormData {
   StudyScheduleFormData({
@@ -30,7 +31,7 @@ class StudyScheduleFormData implements IStudyFormData {
   StudySchedule toStudySchedule() {
     final schedule = StudySchedule();
     schedule.sequence = sequenceType;
-    schedule.sequenceCustom = sequenceTypeCustom;
+    schedule.sequenceCustom = normalizeStudySequenceInput(sequenceTypeCustom);
     schedule.numberOfCycles = numCycles;
     schedule.phaseDuration = phaseDuration;
     schedule.includeBaseline = includeBaseline;

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -48,8 +48,8 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
           keyboardType: TextInputType.text,
           inputFormatters: <TextInputFormatter>[
             FilteringTextInputFormatter.singleLineFormatter,
-            LengthLimitingTextInputFormatter(10),
             StudySequenceFormatter(),
+            LengthLimitingTextInputFormatter(10),
           ],
           //validationMessages: widget.formViewModel.sequenceTypeCustomControl.validationMessages,
         ),

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -74,9 +74,12 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                 //formControl: widget.formViewModel.sequenceTypeControl,
                 onChanged: widget.formViewModel.sequenceTypeControl.disabled
                     ? null
-                    : (PhaseSequence? value) =>
+                    : (PhaseSequence? value) {
+                        setState(() {
                           widget.formViewModel.sequenceTypeControl.value =
-                              value,
+                              value;
+                        });
+                      },
                 initialValue: widget.formViewModel.sequenceTypeControl.value,
                 decoration: InputDecoration(
                   helperText:

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -78,6 +78,8 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                         setState(() {
                           widget.formViewModel.sequenceTypeControl.value =
                               value;
+                          widget.formViewModel.sequenceTypeCustomControl
+                              .updateValueAndValidity();
                         });
                       },
                 initialValue: widget.formViewModel.sequenceTypeControl.value,

--- a/designer_v2/lib/utils/input_formatter.dart
+++ b/designer_v2/lib/utils/input_formatter.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/services.dart';
 
+String normalizeStudySequenceInput(String value) =>
+    value.replaceAll(RegExp(r'\s+'), '').toUpperCase();
+
 class NumericalRangeFormatter extends TextInputFormatter {
   NumericalRangeFormatter({this.min, this.max});
 
@@ -30,14 +33,15 @@ class StudySequenceFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    if (newValue.text == '') {
-      return newValue.copyWith(text: newValue.text.toUpperCase());
-    } else if (newValue.text
-        .replaceAll(' ', '')
-        .contains(RegExp(r'^[abAB]+$'))) {
-      return newValue.copyWith(text: newValue.text.toUpperCase());
-    } else {
+    final normalized = normalizeStudySequenceInput(newValue.text);
+
+    if (normalized.isNotEmpty && !RegExp(r'^[AB]+$').hasMatch(normalized)) {
       return oldValue;
     }
+
+    return TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: normalized.length),
+    );
   }
 }

--- a/designer_v2/test/features/design/interventions/study_schedule_form_controller_mixin_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_controller_mixin_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/features/design/interventions/study_schedule_form_controller_mixin.dart';
+
+void main() {
+  group('StudyScheduleControls', () {
+    test(
+      'does not require an empty custom sequence after switching away from custom sequencing',
+      () {
+        final controls = _StudyScheduleTestControls();
+        final validation = controls.customSequenceRequired;
+        controls.sequenceTypeCustomControl.setValidators(validation.validators);
+
+        controls.sequenceTypeControl.value = PhaseSequence.customized;
+        controls.sequenceTypeCustomControl.value = '';
+        controls.sequenceTypeCustomControl.updateValueAndValidity();
+
+        expect(controls.sequenceTypeCustomControl.valid, isFalse);
+        expect(
+          controls.sequenceTypeCustomControl.errors,
+          contains(ValidationMessage.required),
+        );
+
+        controls.sequenceTypeControl.value = PhaseSequence.alternating;
+        controls.sequenceTypeCustomControl.updateValueAndValidity();
+
+        expect(controls.sequenceTypeCustomControl.valid, isTrue);
+        expect(controls.sequenceTypeCustomControl.errors, isEmpty);
+      },
+    );
+  });
+}
+
+class _StudyScheduleTestControls with StudyScheduleControls {}

--- a/designer_v2/test/features/design/interventions/study_schedule_form_data_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_data_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/features/design/interventions/study_schedule_form_data.dart';
+
+void main() {
+  group('StudyScheduleFormData', () {
+    test(
+      'normalizes custom sequence before applying it to the domain model',
+      () {
+        final data = StudyScheduleFormData(
+          sequenceType: PhaseSequence.customized,
+          sequenceTypeCustom: ' a b B a ',
+          numCycles: 2,
+          phaseDuration: 7,
+          includeBaseline: true,
+        );
+
+        expect(data.toStudySchedule().sequenceCustom, 'ABBA');
+      },
+    );
+  });
+}

--- a/designer_v2/test/utils/input_formatter_test.dart
+++ b/designer_v2/test/utils/input_formatter_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_designer_v2/utils/input_formatter.dart';
 

--- a/designer_v2/test/utils/input_formatter_test.dart
+++ b/designer_v2/test/utils/input_formatter_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_designer_v2/utils/input_formatter.dart';
+
+void main() {
+  group('StudySequenceFormatter', () {
+    final formatter = StudySequenceFormatter();
+
+    TextEditingValue format(String oldText, String newText) {
+      return formatter.formatEditUpdate(
+        TextEditingValue(text: oldText),
+        TextEditingValue(text: newText),
+      );
+    }
+
+    test('uppercases valid sequence input', () {
+      expect(format('', 'abba').text, 'ABBA');
+    });
+
+    test('removes whitespace from pasted sequence input', () {
+      expect(format('', ' A b B A ').text, 'ABBA');
+    });
+
+    test('rejects characters other than A and B', () {
+      expect(format('AB', 'ABC').text, 'AB');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #651

## Summary
- Update the schedule form immediately when sequencing changes, so the custom sequence field appears and disappears without needing a refresh.
- Normalize custom sequences by stripping whitespace and uppercasing A/B values before saving.
- Reject characters outside A/B and cover the formatter/form-data behavior with focused tests.

## Tested
- `dart format` on the touched Designer files and new tests
- `flutter test test\utils\input_formatter_test.dart test\features\design\interventions\study_schedule_form_data_test.dart`
- Frontend testing: custom sequence input strips spaces, uppercases letters, rejects non-A/B input, and hides immediately when switching away from Custom.
