### PR TITLE
chore: remove stale UML docs exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,4 +21,3 @@
 
 # Files that should be ignored for the repository's language statistics and hidden by default in diffs.
 docs/database/** linguist-generated=true
-docs/uml/** linguist-generated=true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -49,7 +49,7 @@ EXCLUDED_DIRECTORIES:
   - linux
   - web
 
-FILTER_REGEX_EXCLUDE: (.*\.g\.dart|.*\/CHANGELOG.md|docs/database/.*|docs/uml/.*|studyu|docker\/supabase\/volumes\/.*|.*\/fastlane\/README.md)
+FILTER_REGEX_EXCLUDE: (.*\.g\.dart|.*\/CHANGELOG.md|docs/database/.*|studyu|docker\/supabase\/volumes\/.*|.*\/fastlane\/README.md)
 
 # Linter specific settings
 


### PR DESCRIPTION
### The change:

### New line of code:  
FILTER_REGEX_EXCLUDE: (.*\.g\.dart|.*\/CHANGELOG.md|docs/database/.*|studyu|docker\/supabase\/volumes\/.*|.*\/fastlane\/README.md)

### Old line of code: 
FILTER_REGEX_EXCLUDE: (.*\.g\.dart|.*\/CHANGELOG.md|docs/database/.***|docs/uml/.***|studyu|docker\/supabase\/volumes\/.*|.*\/fastlane\/README.md)