### PR TITLE
docs: add PR and code review guidelines to CONTRIBUTING

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+<!-- Explain the change, motivation, and link related issues (e.g., Fixes #123) -->
+
+## Visuals
+<!-- REQUIRED: Attach a screenshot for static changes or a screen recording for interactive changes -->
+
+## Testing Steps
+<!-- Provide step-by-step instructions so reviewers can verify this change locally -->
+
+### PR Checklist
+- [ ] `fvm exec melos run qualitycheck` passes
+- [ ] Screenshot or video of the changes attached
+- [ ] Description links related issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,37 @@ Use Conventional Commits, as seen in history: `fix: remove redundant fitbit labe
 ## Security & Configuration Tips
 
 Do not commit secrets. Environment templates live in `flutter_common/lib/envs/`; select them with `--dart-define=STUDYU_ENV=.env.dev` or `.env.local`. Use development or local Supabase instances for routine work; see `supabase/README.md` for local backend setup.
+
+## AI Agent Behavioral Constraints & Execution Rules
+
+You must strictly adhere to the following workspace rules for all file modifications, terminal command executions, commit generations, and pull request actions.
+
+### 1. Code Quality & Pre-Commit Checks
+
+Before staging changes, committing, or opening a Pull Request, you MUST run `fvm exec melos run qualitycheck`.
+
+### 2. Commit Message Enforcement
+
+You must use the Conventional Commits format for all commits. Never generate a generic commit message.
+
+- **Format**: `<type>(<scope>): <description>`
+- **Allowed Types**: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`
+- **Allowed Scopes**: `app`, `designer`, `core`, `flutter_common`, `db`
+- **Case**: The description must be lowercase. Do not end with a period.
+
+### 3. Pull Request Automation
+
+When using the GitHub CLI (`gh`) to open a Pull Request:
+
+1. Parse `.github/pull_request_template.md` to use as the base schema for the PR body.
+2. Complete the `Description` and `Testing Steps` sections with high-density, accurate summaries derived from the git diff.
+3. Keep the checklist interactive (`- [ ]`) but check off the formatting and analyzer items if you successfully ran them in Step 1.
+4. Output a reminder to the user in the chat interface stating that they must manually attach the required screenshot or video before merging.
+
+### 4. Code Reviews (Conventional Comments)
+
+When asked to evaluate code or review a PR, format every single comment exactly to the Conventional Comments specification:
+
+- **Format**: `<label> [decorations]: <subject>\n\n[discussion]`
+- **Valid Labels**: `praise:`, `nitpick:`, `suggestion:`, `issue:`, `todo:`, `question:`, `thought:`, `chore:`, `note:`
+- **Valid Decorations**: `(blocking)`, `(non-blocking)`, `(if-minor)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,15 @@ and dependencies need to have all files generated, when being imported.
 ## Code Style
 
 We use the [Effective Dart](https://dart.dev/guides/language/effective-dart)
-guidelines for Dart and Flutter. Run `melos format` to format your code and
-`dart analyze` to check for any issues.
+guidelines for Dart and Flutter. Run `fvm exec melos run qualitycheck` to
+format, analyze, and regenerate code.
+
+## Frontend
+
+We use Flutter's Material Design with a custom light theme defined in `app/lib/theme.dart`.
+Prefer `Theme.of(context).colorScheme` over hardcoded colors. For responsive layouts, use
+`LayoutBuilder` and `MediaQuery`. Localization is handled via `flutter_localizations` with
+ARB files in `app/lib/l10n/`.
 
 ## Commits
 
@@ -119,9 +126,7 @@ Every pull request should include the following:
 
 ### PR Checklist
 
-- [ ] Code formatted with `melos format`
-- [ ] No analyzer warnings (`dart analyze`)
-- [ ] Generated files updated if models changed (`melos run generate`)
+- [ ] `fvm exec melos run qualitycheck` passes
 - [ ] Screenshot or video of the changes attached
 - [ ] Description links related issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,11 +84,100 @@ and dependencies need to have all files generated, when being imported.
 
 We use the [Effective Dart](https://dart.dev/guides/language/effective-dart)
 guidelines for Dart and Flutter. Run `melos format` to format your code and
-`dart analyze` to check for any issues. For commit messages, we use the
-[Conventional Commits](https://www.conventionalcommits.org) format. For any new
-features or bug fixes, create a new branch and open a pull request.
+`dart analyze` to check for any issues.
 
-Please make sure to follow these guidelines when contributing to the project.
+## Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org) for all
+commit messages. The format is:
+
+```
+<type>(<scope>): <description>
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`.
+Scopes match the package name: `app`, `designer`, `core`, `flutter_common`, `db`.
+
+Examples from this repo:
+
+- `fix: remove redundant fitbit label`
+- `feat(designer): move fitbit credentials to study-level`
+- `chore: update deps + ios deps`
+
+## Pull Requests
+
+For any new features or bug fixes, create a new branch and open a pull request.
+Every pull request should include the following:
+
+1. **Clear title** using Conventional Commits format (e.g.,
+   `fix(designer): resolve drag-and-drop issue`)
+2. **Description** explaining the change, motivation, and any related issues
+3. **Screenshot or video** demonstrating the changes — this is **required** for
+   all PRs. Use a screen recording for interactive changes and a screenshot for
+   static ones.
+4. **Testing steps** so reviewers can verify the change locally
+
+### PR Checklist
+
+- [ ] Code formatted with `melos format`
+- [ ] No analyzer warnings (`dart analyze`)
+- [ ] Generated files updated if models changed (`melos run generate`)
+- [ ] Screenshot or video of the changes attached
+- [ ] Description links related issues
+
+## Code Reviews — Conventional Comments
+
+We use [Conventional Comments](https://conventionalcomments.org/) for all review
+feedback. This standard makes the intent behind each comment clear and
+actionable.
+
+### Format
+
+```
+<label> [decorations]: <subject>
+
+[discussion]
+```
+
+### Labels
+
+| Label | Purpose |
+| --- | --- |
+| **praise:** | Highlight something positive. Leave at least one per review. |
+| **nitpick:** | Trivial preference-based request. Non-blocking by nature. |
+| **suggestion:** | Propose an improvement. Be explicit about *what* and *why*. |
+| **issue:** | Highlight a specific problem. Pair with a suggestion when possible. |
+| **todo:** | Small, necessary change that must be done before merging. |
+| **question:** | Ask for clarification when you're unsure if something is a problem. |
+| **thought:** | Share an idea that came up during review. Non-blocking. |
+| **chore:** | A process-related task needed before acceptance (e.g., run CI job). |
+| **note:** | Non-blocking observation the reader should be aware of. |
+
+### Decorations
+
+Add decorations in parentheses for extra context:
+
+- **(non-blocking)** — should not prevent merging
+- **(blocking)** — must be resolved before merging
+- **(if-minor)** — resolve only if the fix is trivial
+
+### Examples
+
+```
+suggestion (non-blocking): Consider extracting this into a helper method.
+
+It appears in three places and the logic is identical.
+```
+
+```
+issue (blocking): This query fetches all rows without pagination.
+
+On tables with 10k+ rows this will timeout. Can we add a LIMIT clause?
+```
+
+```
+praise: Great use of the builder pattern here — very readable.
+```
 
 ## Flutter Version Management
 


### PR DESCRIPTION
## Problem
CONTRIBUTING.md lacked structured guidance for pull requests and code reviews. Commit conventions were buried in the Code Style paragraph, making them easy to miss.

## Changes
- Reorganized Code Style section to focus only on formatting/linting
- Added dedicated **Commits** section with Conventional Commits format, allowed types, scopes, and real examples from the repo
- Added **Pull Requests** section requiring screenshots/videos, clear descriptions, testing steps, and a PR checklist
- Added **Code Reviews — Conventional Comments** section with the full label set (praise, nitpick, suggestion, issue, todo, question, thought, chore, note), decorations (non-blocking, blocking, if-minor), and concrete examples

## Testing
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm no broken links in the file
- [ ] Review that guidelines align with existing repo conventions