### PR TITLE
fix: migrate deprecated MDI icons

### DIFF
--- a/app/lib/screens/app_onboarding/about.dart
+++ b/app/lib/screens/app_onboarding/about.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/app_onboarding/about.dart
+++ b/app/lib/screens/app_onboarding/about.dart
@@ -22,7 +22,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(MdiIcons.food, size: 80, color: Colors.black),
@@ -72,7 +72,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -112,7 +112,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -152,7 +152,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -192,7 +192,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -201,7 +201,7 @@ class AboutScreen extends StatelessWidget {
                         color: Colors.blue,
                       ),
                     ),
-                    const Expanded(
+                    Expanded(
                       child: Text(
                         'of',
                         textAlign: TextAlign.center,
@@ -246,7 +246,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -286,7 +286,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -326,7 +326,7 @@ class AboutScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const SizedBox(height: 50),
-                Row(
+                const Row(
                   children: [
                     Expanded(
                       child: Icon(
@@ -378,7 +378,7 @@ class AboutScreen extends StatelessWidget {
                 const SizedBox(height: 40),
                 if (context.read<AppState>().activeSubject == null)
                   OutlinedButton.icon(
-                    icon: Icon(MdiIcons.rocket),
+                    icon: const Icon(MdiIcons.rocket),
                     onPressed: () => Navigator.pushNamed(context, Routes.terms),
                     label: Text(
                       AppLocalizations.of(context)!.get_started,

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -80,7 +80,7 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
                       children: [
                         Row(
                           children: [
-                            Icon(MdiIcons.informationOutline),
+                            const Icon(MdiIcons.informationOutline),
                             const SizedBox(width: 8),
                             Text(
                               'Debug Information',
@@ -118,7 +118,7 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
                   children: [
                     Expanded(
                       child: ElevatedButton.icon(
-                        icon: Icon(MdiIcons.emailOutline),
+                        icon: const Icon(MdiIcons.emailOutline),
                         onPressed: () => _contactSupport(context),
                         style: ElevatedButton.styleFrom(
                           foregroundColor: Colors.white,
@@ -132,7 +132,7 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
                     const SizedBox(width: 16),
                     Expanded(
                       child: TextButton.icon(
-                        icon: Icon(MdiIcons.deleteOutline),
+                        icon: const Icon(MdiIcons.deleteOutline),
                         style: TextButton.styleFrom(
                           foregroundColor: Colors.red,
                         ),

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';

--- a/app/lib/screens/app_onboarding/app_outdated_screen.dart
+++ b/app/lib/screens/app_onboarding/app_outdated_screen.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_core/env.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/app/lib/screens/app_onboarding/app_outdated_screen.dart
+++ b/app/lib/screens/app_onboarding/app_outdated_screen.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_core/env.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -17,10 +16,10 @@ class AppOutdatedScreen extends StatelessWidget {
     IconData? storeIcon;
     if (!kIsWeb && Platform.isAndroid) {
       storeUrl = playStoreUrl;
-      storeIcon = MdiIcons.googlePlay;
+      storeIcon = Icons.android;
     } else if (!kIsWeb && Platform.isIOS) {
       storeUrl = appstoreUrl;
-      storeIcon = MdiIcons.apple;
+      storeIcon = Icons.apple;
     }
     return Scaffold(
       body: SafeArea(

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -64,7 +64,7 @@ class _TermsScreenState extends State<TermsScreen> {
               acknowledgment: AppLocalizations.of(context)!.terms_agree,
               onChange: (val) => setState(() => _acceptedTerms = val!),
               isChecked: _acceptedTerms,
-              icon: Icon(MdiIcons.fileDocumentEdit),
+              icon: const Icon(MdiIcons.fileDocumentEdit),
               pdfUrl: appConfig!.appTerms[appLocale.languageCode],
               pdfUrlLabel: AppLocalizations.of(context)!.terms_read,
             ),
@@ -75,13 +75,13 @@ class _TermsScreenState extends State<TermsScreen> {
               acknowledgment: AppLocalizations.of(context)!.privacy_agree,
               onChange: (val) => setState(() => _acceptedPrivacy = val!),
               isChecked: _acceptedPrivacy,
-              icon: Icon(MdiIcons.shieldLock),
+              icon: const Icon(MdiIcons.shieldLock),
               pdfUrl: appConfig.appPrivacy[appLocale.languageCode],
               pdfUrlLabel: AppLocalizations.of(context)!.privacy_read,
             ),
             const SizedBox(height: 30),
             OutlinedButton.icon(
-              icon: Icon(MdiIcons.scaleBalance),
+              icon: const Icon(MdiIcons.scaleBalance),
               onPressed: () async {
                 final uri = Uri.parse(
                   appConfig.imprint[appLocale.languageCode]!,

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/widgets/bottom_onboarding_navigation.dart';

--- a/app/lib/screens/app_onboarding/welcome.dart
+++ b/app/lib/screens/app_onboarding/welcome.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/util/debug_screen.dart';

--- a/app/lib/screens/app_onboarding/welcome.dart
+++ b/app/lib/screens/app_onboarding/welcome.dart
@@ -36,7 +36,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 20),
               OutlinedButton.icon(
-                icon: Icon(MdiIcons.accountBox),
+                icon: const Icon(MdiIcons.accountBox),
                 onPressed: () => Navigator.pushNamed(context, Routes.contact),
                 label: Text(
                   AppLocalizations.of(context)!.contact,
@@ -45,7 +45,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 20),
               OutlinedButton.icon(
-                icon: Icon(MdiIcons.frequentlyAskedQuestions),
+                icon: const Icon(MdiIcons.frequentlyAskedQuestions),
                 onPressed: () => Navigator.pushNamed(context, Routes.faq),
                 label: Text(
                   AppLocalizations.of(context)!.faq,
@@ -54,7 +54,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const Spacer(),
               OutlinedButton.icon(
-                icon: Icon(MdiIcons.rocket, size: 30),
+                icon: const Icon(MdiIcons.rocket, size: 30),
                 onPressed: () => Navigator.pushNamed(context, Routes.terms),
                 label: Text(
                   AppLocalizations.of(context)!.get_started,

--- a/app/lib/screens/study/dashboard/contact_tab/contact_screen.dart
+++ b/app/lib/screens/study/dashboard/contact_tab/contact_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/study/dashboard/dashboard.dart
+++ b/app/lib/screens/study/dashboard/dashboard.dart
@@ -113,14 +113,14 @@ class _DashboardScreenState extends State<DashboardScreen>
         actions: [
           IconButton(
             tooltip: AppLocalizations.of(context)!.contact,
-            icon: Icon(MdiIcons.faceAgent),
+            icon: const Icon(MdiIcons.faceAgent),
             onPressed: () {
               Navigator.pushNamed(context, Routes.contact);
             },
           ),
           IconButton(
             tooltip: AppLocalizations.of(context)!.current_report,
-            icon: Icon(MdiIcons.chartBar),
+            icon: const Icon(MdiIcons.chartBar),
             onPressed: () => Navigator.push(
               context,
               ReportDetailsScreen.routeFor(subject: subject!),
@@ -399,7 +399,7 @@ class StudyFinishedPlaceholder extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () =>
                   Navigator.pushNamed(context, Routes.reportHistory),
-              icon: Icon(MdiIcons.history, size: 24),
+              icon: const Icon(MdiIcons.history, size: 24),
               label: Text(
                 AppLocalizations.of(context)!.report_history,
                 style: const TextStyle(fontSize: 16),
@@ -409,7 +409,7 @@ class StudyFinishedPlaceholder extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () =>
                   Navigator.pushNamed(context, Routes.studySelection),
-              icon: Icon(MdiIcons.clipboardArrowRightOutline, size: 24),
+              icon: const Icon(MdiIcons.clipboardArrowRightOutline, size: 24),
               label: Text(
                 AppLocalizations.of(context)!.study_selection,
                 style: const TextStyle(fontSize: 16),

--- a/app/lib/screens/study/dashboard/dashboard.dart
+++ b/app/lib/screens/study/dashboard/dashboard.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -111,7 +111,7 @@ class _SettingsState extends State<Settings> {
             ),
             const SizedBox(height: 8),
             ElevatedButton.icon(
-              icon: Icon(MdiIcons.exitToApp),
+              icon: const Icon(MdiIcons.exitToApp),
               label: Text(AppLocalizations.of(context)!.opt_out),
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.orange[800],
@@ -171,7 +171,7 @@ class OptOutAlertDialog extends StatelessWidget {
       ),
       actions: [
         ElevatedButton.icon(
-          icon: Icon(MdiIcons.exitToApp),
+          icon: const Icon(MdiIcons.exitToApp),
           label: Text(AppLocalizations.of(context)!.opt_out),
           style: ElevatedButton.styleFrom(backgroundColor: Colors.orange[800]),
           onPressed: () async {

--- a/app/lib/screens/study/dashboard/task_overview_tab/progress_row.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/progress_row.dart
@@ -32,7 +32,7 @@ class _ProgressRowState extends State<ProgressRow> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(MdiIcons.run, size: 30),
+              const Icon(MdiIcons.run, size: 30),
               const SizedBox(width: 8),
               ...intersperseIndexed(
                 (index) => Expanded(
@@ -64,7 +64,7 @@ class _ProgressRowState extends State<ProgressRow> {
                 }),
               ),
               const SizedBox(width: 8),
-              Icon(MdiIcons.flagCheckered, size: 30),
+              const Icon(MdiIcons.flagCheckered, size: 30),
             ],
           ),
         ],

--- a/app/lib/screens/study/dashboard/task_overview_tab/progress_row.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/progress_row.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/util/intervention.dart';
 import 'package:studyu_app/widgets/intervention_card.dart';
 import 'package:studyu_core/core.dart';

--- a/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/task_overview.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/screens/study/dashboard/task_overview_tab/progress_row.dart';
@@ -7,6 +7,7 @@ import 'package:studyu_app/screens/study/dashboard/task_overview_tab/task_box.da
 import 'package:studyu_app/theme.dart';
 import 'package:studyu_app/widgets/intervention_card.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class TaskOverview extends StatefulWidget {
   final StudySubject? subject;
@@ -66,7 +67,7 @@ class _TaskOverviewState extends State<TaskOverview> {
             icon: Icon(
               taskInstance.task is Observation
                   ? MdiIcons.orderBoolAscendingVariant
-                  : MdiIcons.fromString(widget.interventionIcon!),
+                  : MdiIconsHelper.fromString(widget.interventionIcon!),
             ),
           ),
         );

--- a/app/lib/screens/study/onboarding/consent.dart
+++ b/app/lib/screens/study/onboarding/consent.dart
@@ -74,7 +74,7 @@ class _ConsentScreenState extends State<ConsentScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.consent),
-        leading: Icon(MdiIcons.textBoxCheck),
+        leading: const Icon(MdiIcons.textBoxCheck),
         actions: [
           IconButton(
             icon: const Icon(Icons.save),

--- a/app/lib/screens/study/onboarding/consent.dart
+++ b/app/lib/screens/study/onboarding/consent.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
@@ -13,6 +13,7 @@ import 'package:studyu_app/util/save_pdf.dart';
 import 'package:studyu_app/widgets/bottom_onboarding_navigation.dart';
 import 'package:studyu_app/widgets/html_text.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class ConsentScreen extends StatefulWidget {
   const ConsentScreen({super.key});
@@ -231,7 +232,7 @@ class ConsentCard extends StatelessWidget {
                 children: [
                   if (consent!.iconName.isNotEmpty)
                     Icon(
-                      MdiIcons.fromString(consent!.iconName),
+                      MdiIconsHelper.fromString(consent!.iconName),
                       color: theme.primaryColor,
                     )
                   else
@@ -260,7 +261,7 @@ class ConsentCard extends StatelessWidget {
             children: [
               if (consent!.iconName.isNotEmpty)
                 Icon(
-                  MdiIcons.fromString(consent!.iconName),
+                  MdiIconsHelper.fromString(consent!.iconName),
                   size: 60,
                   color: Colors.blue,
                 )

--- a/app/lib/screens/study/onboarding/eligibility_screen.dart
+++ b/app/lib/screens/study/onboarding/eligibility_screen.dart
@@ -125,7 +125,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   }
 
   Widget _constructPassBanner() => MaterialBanner(
-    leading: Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 32),
+    leading: const Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 32),
     content: Text(
       AppLocalizations.of(context)!.eligible_yes,
       style: Theme.of(context).textTheme.titleMedium,
@@ -136,7 +136,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   );
 
   Widget _constructFailBanner() => MaterialBanner(
-    leading: Icon(MdiIcons.closeCircle, color: Colors.red, size: 32),
+    leading: const Icon(MdiIcons.closeCircle, color: Colors.red, size: 32),
     content: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -177,7 +177,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
         title: Text(
           AppLocalizations.of(context)!.eligibility_questionnaire_title,
         ),
-        leading: Icon(MdiIcons.clipboardList),
+        leading: const Icon(MdiIcons.clipboardList),
       ),
       body: Column(
         children: [

--- a/app/lib/screens/study/onboarding/eligibility_screen.dart
+++ b/app/lib/screens/study/onboarding/eligibility_screen.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/screens/study/onboarding/onboarding_progress.dart';
 import 'package:studyu_app/widgets/bottom_onboarding_navigation.dart';

--- a/app/lib/screens/study/onboarding/eligibility_screen.dart
+++ b/app/lib/screens/study/onboarding/eligibility_screen.dart
@@ -125,7 +125,11 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   }
 
   Widget _constructPassBanner() => MaterialBanner(
-    leading: const Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 32),
+    leading: const Icon(
+      MdiIcons.checkboxMarkedCircle,
+      color: Colors.green,
+      size: 32,
+    ),
     content: Text(
       AppLocalizations.of(context)!.eligible_yes,
       style: Theme.of(context).textTheme.titleMedium,

--- a/app/lib/screens/study/onboarding/intervention_selection.dart
+++ b/app/lib/screens/study/onboarding/intervention_selection.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/study/onboarding/intervention_selection.dart
+++ b/app/lib/screens/study/onboarding/intervention_selection.dart
@@ -106,7 +106,7 @@ class _InterventionSelectionScreenState
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.intervention_selection_title),
-        leading: Icon(MdiIcons.formatListChecks),
+        leading: const Icon(MdiIcons.formatListChecks),
       ),
       body: SingleChildScrollView(
         child: Center(

--- a/app/lib/screens/study/onboarding/journey_overview.dart
+++ b/app/lib/screens/study/onboarding/journey_overview.dart
@@ -54,7 +54,7 @@ class _JourneyOverviewScreen extends State<JourneyOverviewScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.your_journey),
-        leading: Icon(MdiIcons.mapMarkerPath),
+        leading: const Icon(MdiIcons.mapMarkerPath),
       ),
       body: Center(
         child: SingleChildScrollView(

--- a/app/lib/screens/study/onboarding/journey_overview.dart
+++ b/app/lib/screens/study/onboarding/journey_overview.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:intl/intl.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
@@ -8,6 +8,7 @@ import 'package:studyu_app/routes.dart';
 import 'package:studyu_app/screens/study/onboarding/onboarding_progress.dart';
 import 'package:studyu_app/widgets/bottom_onboarding_navigation.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:timeline_tile/timeline_tile.dart';
 
 class JourneyOverviewScreen extends StatefulWidget {
@@ -182,7 +183,7 @@ class IconIndicator extends StatelessWidget {
         color: color ?? Theme.of(context).colorScheme.secondary,
       ),
       child: Center(
-        child: Icon(MdiIcons.fromString(iconName), color: Colors.white),
+        child: Icon(MdiIconsHelper.fromString(iconName), color: Colors.white),
       ),
     );
   }

--- a/app/lib/screens/study/onboarding/kickoff.dart
+++ b/app/lib/screens/study/onboarding/kickoff.dart
@@ -69,7 +69,11 @@ class _KickoffScreen extends State<KickoffScreen> {
           width: 64,
           child: CircularProgressIndicator(),
         )
-      : const Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 64);
+      : const Icon(
+          MdiIcons.checkboxMarkedCircle,
+          color: Colors.green,
+          size: 64,
+        );
 
   String _getStatusText(BuildContext context) => !ready
       ? AppLocalizations.of(context)!.setting_up_study

--- a/app/lib/screens/study/onboarding/kickoff.dart
+++ b/app/lib/screens/study/onboarding/kickoff.dart
@@ -69,7 +69,7 @@ class _KickoffScreen extends State<KickoffScreen> {
           width: 64,
           child: CircularProgressIndicator(),
         )
-      : Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 64);
+      : const Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 64);
 
   String _getStatusText(BuildContext context) => !ready
       ? AppLocalizations.of(context)!.setting_up_study

--- a/app/lib/screens/study/onboarding/kickoff.dart
+++ b/app/lib/screens/study/onboarding/kickoff.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
@@ -80,7 +80,7 @@ class _KickoffScreen extends State<KickoffScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(subject!.study.title!),
-        leading: Icon(MdiIcons.fromString(subject!.study.iconName)),
+        leading: Icon(MdiIconsHelper.fromString(subject!.study.iconName)),
       ),
       body: Builder(
         builder: (buildContext) {

--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -71,7 +71,7 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        leading: Icon(MdiIcons.textLong),
+        leading: const Icon(MdiIcons.textLong),
         title: Text(AppLocalizations.of(context)!.study_overview_title),
       ),
       body: SingleChildScrollView(

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -130,7 +130,7 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
                   children: [
                     MaterialBanner(
                       padding: const EdgeInsets.all(8),
-                      leading: Icon(
+                      leading: const Icon(
                         MdiIcons.exclamationThick,
                         color: Colors.orange,
                         size: 32,
@@ -196,7 +196,7 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
               Padding(
                 padding: const EdgeInsets.all(8),
                 child: OutlinedButton.icon(
-                  icon: Icon(MdiIcons.key),
+                  icon: const Icon(MdiIcons.key),
                   onPressed: () async {
                     await showDialog(
                       context: context,

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/screens/study/report/report_history.dart
+++ b/app/lib/screens/study/report/report_history.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
@@ -65,7 +65,7 @@ class ReportHistoryItem extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: [
                 Icon(
-                  MdiIcons.fromString(subject.study.iconName) ??
+                  MdiIconsHelper.fromString(subject.study.iconName) ??
                       MdiIcons.accountHeart,
                   color: isActiveStudy ? Colors.white : Colors.black,
                 ),

--- a/app/lib/util/intervention.dart
+++ b/app/lib/util/intervention.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 Widget interventionIcon(Intervention intervention, {Color? color}) {
   if (intervention.isBaseline()) {
@@ -9,7 +10,7 @@ Widget interventionIcon(Intervention intervention, {Color? color}) {
 
   return intervention.icon.isNotEmpty
       ? Icon(
-          MdiIcons.fromString(intervention.icon),
+          MdiIconsHelper.fromString(intervention.icon),
           color: color ?? Colors.white,
         )
       : Text(

--- a/app/lib/widgets/intervention_card.dart
+++ b/app/lib/widgets/intervention_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/widgets/html_text.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class InterventionCard extends StatelessWidget {
   final Intervention intervention;
@@ -66,7 +66,7 @@ class InterventionCardTitle extends StatelessWidget {
     return ListTile(
       onTap: onTap,
       leading: Icon(
-        MdiIcons.fromString(intervention!.icon),
+        MdiIconsHelper.fromString(intervention!.icon),
         color: theme.colorScheme.secondary,
       ),
       trailing: showCheckbox
@@ -94,7 +94,7 @@ class InterventionCardTitle extends StatelessWidget {
                   return AlertDialog(
                     title: ListTile(
                       leading: Icon(
-                        MdiIcons.fromString(intervention!.icon),
+                        MdiIconsHelper.fromString(intervention!.icon),
                         color: theme.colorScheme.secondary,
                       ),
                       dense: true,

--- a/app/lib/widgets/questionnaire/audio_recording_question_widget.dart
+++ b/app/lib/widgets/questionnaire/audio_recording_question_widget.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:record/record.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';

--- a/app/lib/widgets/questionnaire/image_capturing_question_widget.dart
+++ b/app/lib/widgets/questionnaire/image_capturing_question_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';

--- a/app/lib/widgets/round_checkbox.dart
+++ b/app/lib/widgets/round_checkbox.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 
 class RoundCheckbox extends StatelessWidget {
   final Function(bool)? onChanged;

--- a/app/lib/widgets/study_tile.dart
+++ b/app/lib/widgets/study_tile.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class StudyTile extends StatelessWidget {
   final String? title;
@@ -57,7 +57,7 @@ class StudyTile extends StatelessWidget {
           ),
           subtitle: Center(child: Text(description ?? '')),
           leading: Icon(
-            MdiIcons.fromString(iconName),
+            MdiIconsHelper.fromString(iconName),
             color: theme.primaryColor,
           ),
         ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_local_notifications: ^21.0.0
   flutter_localizations:
     sdk: flutter
+  flutter_material_design_icons: ^3.1.0+7447
   flutter_native_splash: ^2.4.7
   flutter_svg: ^2.2.4
   flutter_timezone: ^5.0.2
@@ -35,7 +36,6 @@ dependencies:
   intersperse: ^2.0.0
   intl: ^0.20.2
   introduction_screen: ^3.1.14
-  material_design_icons_flutter: ^7.0.7296
   package_info_plus: ^9.0.0
   path: ^1.9.1
   path_drawing: ^1.0.1

--- a/designer_v2/lib/common_views/icon_picker.dart
+++ b/designer_v2/lib/common_views/icon_picker.dart
@@ -2,12 +2,12 @@ import 'dart:math';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_designer_v2/common_views/dialog.dart';
 import 'package:studyu_designer_v2/common_views/mouse_events.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/utils/typings.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class IconPack {
   static final defaultPack = IconPack.material;
@@ -16,9 +16,9 @@ class IconPack {
     final List<IconOption> iconOptions = [];
 
     // TODO: migrate app + designer to standard material icons & remove library
-    final iconNames = MdiIcons.getNames();
+    final iconNames = MdiIconsHelper.getNames();
     for (final iconName in iconNames) {
-      final iconData = MdiIcons.fromString(iconName);
+      final iconData = MdiIconsHelper.fromString(iconName);
       if (iconData != null) {
         iconOptions.add(IconOption(iconName, iconData));
       }

--- a/designer_v2/lib/common_views/standard_table.dart
+++ b/designer_v2/lib/common_views/standard_table.dart
@@ -393,9 +393,9 @@ class _StandardTableState<T> extends State<StandardTable<T>> {
   void sortAction(int i, {PointerEvent? hover}) {
     if (!widget.inputColumns[i].sortable) return;
 
-    final ascendingIcon = Icon(MdiIcons.arrowUp);
-    final descendingIcon = Icon(MdiIcons.arrowDown);
-    final hoveredIcon = Icon(MdiIcons.arrowUp, color: Colors.grey);
+    const ascendingIcon = Icon(MdiIcons.arrowUp);
+    const descendingIcon = Icon(MdiIcons.arrowDown);
+    const hoveredIcon = Icon(MdiIcons.arrowUp, color: Colors.grey);
 
     setState(() {
       // Clicked

--- a/designer_v2/lib/common_views/standard_table.dart
+++ b/designer_v2/lib/common_views/standard_table.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_designer_v2/common_views/action_inline_menu.dart';
 import 'package:studyu_designer_v2/common_views/action_menu.dart';
 import 'package:studyu_designer_v2/common_views/action_popup_menu.dart';

--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -65,10 +65,10 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
   }
 
   Icon? _getIcon() {
-    final ascendingIcon = Icon(MdiIcons.arrowUp);
-    final descendingIcon = Icon(MdiIcons.arrowDown);
-    final hoveredAscendingIcon = Icon(MdiIcons.arrowUp, color: Colors.grey);
-    final hoveredDescendingIcon = Icon(MdiIcons.arrowDown, color: Colors.grey);
+    const ascendingIcon = Icon(MdiIcons.arrowUp);
+    const descendingIcon = Icon(MdiIcons.arrowDown);
+    const hoveredAscendingIcon = Icon(MdiIcons.arrowUp, color: Colors.grey);
+    const hoveredDescendingIcon = Icon(MdiIcons.arrowDown, color: Colors.grey);
 
     if (!widget.sortable) {
       return null;

--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_designer_v2/common_views/mouse_events.dart';
 
 class StudiesTableColumnHeader extends StatefulWidget {

--- a/designer_v2/lib/features/dashboard/studies_table_item.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/common_views/action_popup_menu.dart';
 import 'package:studyu_designer_v2/common_views/mouse_events.dart';

--- a/designer_v2/lib/features/study/study_actions.dart
+++ b/designer_v2/lib/features/study/study_actions.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
 
 Map<StudyActionType, IconData> studyActionIcons = {

--- a/designer_v2/lib/services/notifications.dart
+++ b/designer_v2/lib/services/notifications.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/services/notification_types.dart';
 

--- a/designer_v2/pubspec.yaml
+++ b/designer_v2/pubspec.yaml
@@ -22,13 +22,13 @@ dependencies:
   flutter_colorpicker: ^1.1.0
   flutter_localizations:
     sdk: flutter
+  flutter_material_design_icons: ^3.1.0+7447
   flutter_riverpod: ^3.3.1
   flutter_web_plugins:
     sdk: flutter
   go_router: ^17.1.0
   intl: ^0.20.2
   material_color_utilities: ^0.13.0 # integration_test
-  material_design_icons_flutter: ^7.0.7296
   package_info_plus: ^9.0.0
   pointer_interceptor: ^0.10.1+2
   reactive_color_picker: ^2.2.2

--- a/flutter_common/lib/src/utils/mdi_icons_helper.dart
+++ b/flutter_common/lib/src/utils/mdi_icons_helper.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
+
+/// Helper shim that preserves the [MdiIcons.fromString] and [MdiIcons.getNames]
+/// API from the original `material_design_icons_flutter` package.
+///
+/// The FaFre `flutter_material_design_icons` package provides [MdiIcons.values]
+/// and [MdiIcons.maybeMetadataOf] but does not include `fromString`/`getNames`.
+/// This shim builds a name-to-IconData map from the metadata at runtime.
+///
+/// Note: [MdiMetadata.name] returns kebab-case (e.g. `'account-heart'`)
+/// whereas the old package used camelCase (e.g. `'accountHeart'`).
+/// This helper converts keys back to camelCase for backwards compatibility.
+class MdiIconsHelper {
+  MdiIconsHelper._();
+
+  static Map<String, IconData>? _iconMap;
+
+  static Map<String, IconData> get _map {
+    _iconMap ??= {
+      for (final icon in MdiIcons.values)
+        _toCamelCase(MdiIcons.maybeMetadataOf(icon)?.name ?? ''): icon,
+    };
+    return _iconMap!;
+  }
+
+  /// Converts kebab-case (MDI metadata name) to camelCase (Dart constant name).
+  /// e.g. `'ab-testing'` → `'abTesting'`, `'account-alert-outline'` → `'accountAlertOutline'`
+  static String _toCamelCase(String kebab) {
+    if (kebab.isEmpty) return kebab;
+    final parts = kebab.split('-');
+    return parts.first +
+        parts.skip(1).map((p) => p[0].toUpperCase() + p.substring(1)).join();
+  }
+
+  /// Returns the [IconData] for the given camelCase icon name,
+  /// or `null` if not found.
+  static IconData? fromString(String name) {
+    return _map[name];
+  }
+
+  /// Returns all available icon names in camelCase format.
+  static List<String> getNames() => _map.keys.toList();
+}

--- a/flutter_common/lib/studyu_flutter_common.dart
+++ b/flutter_common/lib/studyu_flutter_common.dart
@@ -1,5 +1,6 @@
 export 'src/utils/env_loader.dart';
 export 'src/utils/localization.dart';
+export 'src/utils/mdi_icons_helper.dart';
 export 'src/utils/retry_future_builder.dart';
 export 'src/utils/storage.dart';
 export 'src/utils/user.dart';

--- a/flutter_common/pubspec.yaml
+++ b/flutter_common/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_dotenv: ^6.0.0
+  flutter_material_design_icons: ^3.1.0+7447
   flutter_secure_storage: ^10.0.0
   lint: ^2.8.0
   shared_preferences: ^2.5.4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -689,6 +689,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_material_design_icons:
+    dependency: transitive
+    description:
+      name: flutter_material_design_icons
+      sha256: "9a7b6308736e328f9ce2249c3727a56a289c915a65ebf1b1b5f237c8232e92b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0+7447"
   flutter_native_splash:
     dependency: transitive
     description:
@@ -1165,14 +1173,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
-  material_design_icons_flutter:
-    dependency: transitive
-    description:
-      name: material_design_icons_flutter
-      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.7296"
   melos:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
## Description
Replaces deprecated `material_design_icons_flutter` usage and package with `flutter_material_design_icons` for store-link icons.

Changes included:
- migrate dependency from `material_design_icons_flutter` to `flutter_material_design_icons`
- replace deprecated icon usages with Flutter built-ins where appropriate (`Icons.android`, `Icons.apple`)
- apply follow-up const/format cleanups required for analyzer/formatter on this branch

## Testing Steps
1. Checkout this branch.
2. Run `fvm exec melos run qualitycheck`.
3. Launch app flows containing store-link icons and onboarding screens.
4. Verify icons render correctly and no analyzer issues remain.
