### PR TITLE
feat(test): add stable ValueKeys for MCP automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ megalinter-reports/
 
 # No localization file on workspace level
 l10n-missing.txt
+
+# Local OpenCode state
+.opencode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,15 +14,19 @@ StudyU is a Melos-managed Dart/Flutter workspace. The root `pubspec.yaml` define
 
 Use FVM and Melos from the repository root. Run `fvm install` if the configured SDK is missing.
 
-- `dart pub get`: installs root dependencies.
-- `melos bootstrap`: links workspace packages and installs package dependencies.
-- `melos run app`: runs the StudyU app on Chrome at port `8080`.
-- `melos run designer_v2`: runs Designer v2 on Chrome at port `8081`.
-- `melos run dev:app` or `melos run dev:designer_v2`: runs against `.env.dev`.
-- `melos run local:app` or `melos run local:designer_v2`: runs against `.env.local`.
-- `melos run generate`: runs `build_runner` for generated Dart files.
-- `melos run qualitycheck`: formats, regenerates, and analyzes the workspace.
-- `melos run build:web`: builds both web apps.
+Prefix `dart`/`flutter` commands with `fvm`, and `melos` commands with `fvm exec`, to use the
+FVM-managed SDK version.
+
+- `fvm dart pub get`: installs root dependencies.
+- `fvm exec melos bootstrap`: links workspace packages and installs package dependencies.
+- `fvm exec melos run app`: runs the StudyU app on Chrome at port `8080`.
+- `fvm exec melos run designer_v2`: runs Designer v2 on Chrome at port `8081`.
+- `fvm exec melos run dev:app` or `fvm exec melos run dev:designer_v2`: runs against `.env.dev`.
+- `fvm exec melos run local:app` or `fvm exec melos run local:designer_v2`: runs against
+  `.env.local`.
+- `fvm exec melos run generate`: runs `build_runner` for generated Dart files.
+- `fvm exec melos run qualitycheck`: formats, regenerates, and analyzes the workspace.
+- `fvm exec melos run build:web`: builds both web apps.
 
 ## Coding Style & Naming Conventions
 

--- a/app/lib/driver_main.dart
+++ b/app/lib/driver_main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:studyu_app/main.dart' as app_main;
+
+Future<void> main() async {
+  enableFlutterDriverExtension();
+  await app_main.main();
+}

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/app/lib/screens/app_onboarding/onboarding_screen.dart
+++ b/app/lib/screens/app_onboarding/onboarding_screen.dart
@@ -41,9 +41,10 @@ class OnboardingScreen extends StatelessWidget {
         ),
       ],
       showBackButton: true,
-      back: Text(l10n.back),
-      next: Text(l10n.next),
+      back: Text(l10n.back, key: const ValueKey('onboarding_back')),
+      next: Text(l10n.next, key: const ValueKey('onboarding_next')),
       done: Text(
+        key: const ValueKey('onboarding_done'),
         l10n.get_started,
         style: const TextStyle(fontWeight: FontWeight.w600),
       ),

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -37,6 +37,7 @@ class _TermsScreenState extends State<TermsScreen> {
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
         hideBack: true,
+        nextButtonKey: const ValueKey('terms_continue'),
         onNext: userCanContinue()
             ? () async {
                 final success = await anonymousSignUp();
@@ -59,6 +60,7 @@ class _TermsScreenState extends State<TermsScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             LegalSection(
+              checkboxKey: const ValueKey('terms_checkbox'),
               title: AppLocalizations.of(context)!.terms,
               description: AppLocalizations.of(context)!.terms_content,
               acknowledgment: AppLocalizations.of(context)!.terms_agree,
@@ -70,6 +72,7 @@ class _TermsScreenState extends State<TermsScreen> {
             ),
             const SizedBox(height: 20),
             LegalSection(
+              checkboxKey: const ValueKey('privacy_checkbox'),
               title: AppLocalizations.of(context)!.privacy,
               description: AppLocalizations.of(context)!.privacy_content,
               acknowledgment: AppLocalizations.of(context)!.privacy_agree,
@@ -81,6 +84,7 @@ class _TermsScreenState extends State<TermsScreen> {
             ),
             const SizedBox(height: 30),
             OutlinedButton.icon(
+              key: const ValueKey('imprint_button'),
               icon: Icon(MdiIcons.scaleBalance),
               onPressed: () async {
                 final uri = Uri.parse(
@@ -108,6 +112,7 @@ class LegalSection extends StatelessWidget {
   final String? acknowledgment;
   final bool? isChecked;
   final ValueChanged<bool?>? onChange;
+  final Key? checkboxKey;
 
   const LegalSection({
     super.key,
@@ -119,6 +124,7 @@ class LegalSection extends StatelessWidget {
     this.acknowledgment,
     this.isChecked,
     this.onChange,
+    this.checkboxKey,
   });
 
   @override
@@ -146,6 +152,7 @@ class LegalSection extends StatelessWidget {
           label: Text(pdfUrlLabel!),
         ),
         CheckboxListTile(
+          key: checkboxKey,
           title: Text(acknowledgment!),
           value: isChecked,
           onChanged: onChange,

--- a/app/lib/screens/app_onboarding/welcome.dart
+++ b/app/lib/screens/app_onboarding/welcome.dart
@@ -27,6 +27,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 20),
               OutlinedButton.icon(
+                key: const ValueKey('welcome_about'),
                 icon: const Icon(Icons.info),
                 onPressed: () => Navigator.pushNamed(context, Routes.about),
                 label: Text(
@@ -36,6 +37,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 20),
               OutlinedButton.icon(
+                key: const ValueKey('welcome_contact'),
                 icon: Icon(MdiIcons.accountBox),
                 onPressed: () => Navigator.pushNamed(context, Routes.contact),
                 label: Text(
@@ -45,6 +47,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 20),
               OutlinedButton.icon(
+                key: const ValueKey('welcome_faq'),
                 icon: Icon(MdiIcons.frequentlyAskedQuestions),
                 onPressed: () => Navigator.pushNamed(context, Routes.faq),
                 label: Text(
@@ -54,6 +57,7 @@ class WelcomeScreen extends StatelessWidget {
               ),
               const Spacer(),
               OutlinedButton.icon(
+                key: const ValueKey('welcome_get_started'),
                 icon: Icon(MdiIcons.rocket, size: 30),
                 onPressed: () => Navigator.pushNamed(context, Routes.terms),
                 label: Text(

--- a/app/lib/screens/study/dashboard/dashboard.dart
+++ b/app/lib/screens/study/dashboard/dashboard.dart
@@ -112,6 +112,7 @@ class _DashboardScreenState extends State<DashboardScreen>
         forceMaterialTransparency: true,
         actions: [
           IconButton(
+            key: const ValueKey('dashboard_contact'),
             tooltip: AppLocalizations.of(context)!.contact,
             icon: Icon(MdiIcons.faceAgent),
             onPressed: () {
@@ -119,6 +120,7 @@ class _DashboardScreenState extends State<DashboardScreen>
             },
           ),
           IconButton(
+            key: const ValueKey('dashboard_report'),
             tooltip: AppLocalizations.of(context)!.current_report,
             icon: Icon(MdiIcons.chartBar),
             onPressed: () => Navigator.push(
@@ -127,6 +129,7 @@ class _DashboardScreenState extends State<DashboardScreen>
             ),
           ),
           PopupMenuButton<OverflowMenuItem>(
+            key: const ValueKey('dashboard_menu'),
             onSelected: (value) {
               if (value.routeName != null) {
                 Navigator.pushNamed(context, value.routeName!);

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -55,6 +55,7 @@ class _SettingsState extends State<Settings> {
             Text('${AppLocalizations.of(context)!.language}:'),
             const SizedBox(width: 5),
             DropdownButton<Locale>(
+              key: const ValueKey('settings_language_dropdown'),
               value: _selectedValue,
               items: dropDownItems,
               onChanged: (value) {
@@ -79,6 +80,7 @@ class _SettingsState extends State<Settings> {
             ),
             const SizedBox(width: 5),
             Switch(
+              key: const ValueKey('settings_analytics_switch'),
               value: _analyticsValue!,
               onChanged: (value) {
                 setState(() {
@@ -97,6 +99,7 @@ class _SettingsState extends State<Settings> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
+      key: const ValueKey('settings_screen'),
       appBar: AppBar(title: Text(AppLocalizations.of(context)!.settings)),
       body: Center(
         child: Column(
@@ -111,6 +114,7 @@ class _SettingsState extends State<Settings> {
             ),
             const SizedBox(height: 8),
             ElevatedButton.icon(
+              key: const ValueKey('settings_opt_out'),
               icon: Icon(MdiIcons.exitToApp),
               label: Text(AppLocalizations.of(context)!.opt_out),
               style: ElevatedButton.styleFrom(
@@ -125,6 +129,7 @@ class _SettingsState extends State<Settings> {
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
+              key: const ValueKey('settings_delete_data'),
               icon: const Icon(Icons.delete),
               label: Text(AppLocalizations.of(context)!.delete_data),
               style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
@@ -151,6 +156,7 @@ class OptOutAlertDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AlertDialog(
+      key: const ValueKey('opt_out_dialog'),
       title: Text('${AppLocalizations.of(context)!.opt_out}?'),
       content: RichText(
         text: TextSpan(
@@ -171,6 +177,7 @@ class OptOutAlertDialog extends StatelessWidget {
       ),
       actions: [
         ElevatedButton.icon(
+          key: const ValueKey('opt_out_confirm'),
           icon: Icon(MdiIcons.exitToApp),
           label: Text(AppLocalizations.of(context)!.opt_out),
           style: ElevatedButton.styleFrom(backgroundColor: Colors.orange[800]),
@@ -200,10 +207,12 @@ class DeleteAlertDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => AlertDialog(
+    key: const ValueKey('delete_data_dialog'),
     title: Text('${AppLocalizations.of(context)!.delete_data}?'),
     content: Text(AppLocalizations.of(context)!.hard_delete_desc),
     actions: [
       ElevatedButton.icon(
+        key: const ValueKey('delete_data_confirm'),
         icon: const Icon(Icons.delete),
         label: Text(AppLocalizations.of(context)!.delete_data),
         style: ElevatedButton.styleFrom(backgroundColor: Colors.red),

--- a/app/lib/screens/study/dashboard/task_overview_tab/task_box.dart
+++ b/app/lib/screens/study/dashboard/task_overview_tab/task_box.dart
@@ -54,6 +54,7 @@ class _TaskBoxState extends State<TaskBox> {
     );
     final isTaskOpen = !completed && isInsidePeriod || isPreview || kDebugMode;
     return Card(
+      key: ValueKey('task_box_${widget.taskInstance.task.id}'),
       elevation: 2,
       child: InkWell(
         onTap: isTaskOpen ? _navigateToTaskScreen : () {},
@@ -68,6 +69,7 @@ class _TaskBoxState extends State<TaskBox> {
             ),
             if (isInsidePeriod || isPreview || completed)
               RoundCheckbox(
+                key: const ValueKey('task_box_checkbox'),
                 value: completed, //_isCompleted,
                 onChanged: (value) =>
                     isTaskOpen ? _navigateToTaskScreen() : () {},

--- a/app/lib/screens/study/onboarding/consent.dart
+++ b/app/lib/screens/study/onboarding/consent.dart
@@ -164,6 +164,7 @@ class _ConsentScreenState extends State<ConsentScreen> {
                     itemCount: consentList.length,
                     itemBuilder: (context, index) {
                       return ConsentCard(
+                        key: ValueKey('consent_card_$index'),
                         consent: consentList[index],
                         isChecked: boxLogic[index],
                         index: index,
@@ -180,6 +181,8 @@ class _ConsentScreenState extends State<ConsentScreen> {
         ),
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
+        backButtonKey: const ValueKey('consent_decline'),
+        nextButtonKey: const ValueKey('consent_accept'),
         backLabel: AppLocalizations.of(context)!.decline,
         backIcon: const Icon(Icons.close),
         onBack: () => Navigator.popUntil(

--- a/app/lib/screens/study/onboarding/eligibility_screen.dart
+++ b/app/lib/screens/study/onboarding/eligibility_screen.dart
@@ -125,6 +125,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   }
 
   Widget _constructPassBanner() => MaterialBanner(
+    key: const ValueKey('eligibility_pass_banner'),
     leading: Icon(MdiIcons.checkboxMarkedCircle, color: Colors.green, size: 32),
     content: Text(
       AppLocalizations.of(context)!.eligible_yes,
@@ -136,6 +137,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   );
 
   Widget _constructFailBanner() => MaterialBanner(
+    key: const ValueKey('eligibility_fail_banner'),
     leading: Icon(MdiIcons.closeCircle, color: Colors.red, size: 32),
     content: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -158,6 +160,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
     ),
     actions: [
       TextButton(
+        key: const ValueKey('eligibility_back'),
         onPressed: _finish,
         child: Text(AppLocalizations.of(context)!.eligible_back),
       ),
@@ -173,6 +176,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
+      key: const ValueKey('eligibility_screen'),
       appBar: AppBar(
         title: Text(
           AppLocalizations.of(context)!.eligibility_questionnaire_title,
@@ -200,6 +204,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
         ],
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
+        nextButtonKey: const ValueKey('eligibility_continue'),
         onNext: activeResult?.eligible ?? false ? _finish : null,
         progress: const OnboardingProgress(stage: 0, progress: 0.5),
       ),

--- a/app/lib/screens/study/onboarding/intervention_selection.dart
+++ b/app/lib/screens/study/onboarding/intervention_selection.dart
@@ -59,10 +59,12 @@ class _InterventionSelectionScreenState
     }
 
     return ListView.builder(
+      key: const ValueKey('intervention_selection_list'),
       physics: const NeverScrollableScrollPhysics(),
       shrinkWrap: true,
       itemCount: interventions.length,
       itemBuilder: (context, index) => Card(
+        key: ValueKey('intervention_card_${interventions[index].id}'),
         child: InterventionCard(
           interventions[index],
           showCheckbox: true,
@@ -104,6 +106,7 @@ class _InterventionSelectionScreenState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
+      key: const ValueKey('intervention_selection_screen'),
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.intervention_selection_title),
         leading: Icon(MdiIcons.formatListChecks),
@@ -124,6 +127,7 @@ class _InterventionSelectionScreenState
         ),
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
+        nextButtonKey: const ValueKey('intervention_selection_continue'),
         onNext: selectedInterventionIds.length == 2 ? onFinished : null,
         progress: OnboardingProgress(
           stage: 1,

--- a/app/lib/screens/study/onboarding/journey_overview.dart
+++ b/app/lib/screens/study/onboarding/journey_overview.dart
@@ -51,6 +51,7 @@ class _JourneyOverviewScreen extends State<JourneyOverviewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: const ValueKey('journey_overview_screen'),
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.your_journey),
         leading: Icon(MdiIcons.mapMarkerPath),
@@ -69,6 +70,7 @@ class _JourneyOverviewScreen extends State<JourneyOverviewScreen> {
         ),
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
+        nextButtonKey: const ValueKey('journey_overview_next'),
         onNext: () => getConsentAndNavigateToDashboard(context),
         progress: const OnboardingProgress(stage: 2, progress: 0.5),
       ),
@@ -87,12 +89,14 @@ class Timeline extends StatelessWidget {
     final interventionsInOrder = subject!.getInterventionsInOrder();
     final now = DateTime.now();
     return Column(
+      key: const ValueKey('journey_timeline'),
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         ...interventionsInOrder.asMap().entries.map((entry) {
           final index = entry.key;
           final intervention = entry.value;
           return InterventionTile(
+            key: ValueKey('journey_intervention_tile_$index'),
             title: intervention.name,
             iconName: intervention.icon,
             color: intervention.isBaseline()
@@ -105,6 +109,7 @@ class Timeline extends StatelessWidget {
           );
         }),
         InterventionTile(
+          key: const ValueKey('journey_results_tile'),
           title: AppLocalizations.of(context)!.journey_results_available,
           iconName: 'flagCheckered',
           color: Colors.green,

--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -70,6 +70,7 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: const ValueKey('study_overview_screen'),
       appBar: AppBar(
         leading: Icon(MdiIcons.textLong),
         title: Text(AppLocalizations.of(context)!.study_overview_title),
@@ -87,6 +88,7 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
         ),
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
+        nextButtonKey: const ValueKey('study_overview_next'),
         onNext: context.watch<AppState>().selectedStudy!.hasEligibilityCheck
             ? () => navigateToEligibilityCheck(context)
             : () => navigateToJourney(context),
@@ -107,8 +109,10 @@ class StudyDetailsView extends StatelessWidget {
     final theme = Theme.of(context);
     final studyLength = study!.studyLength;
     return Column(
+      key: const ValueKey('study_details'),
       children: [
         ListTile(
+          key: const ValueKey('study_duration_tile'),
           title: Text(
             AppLocalizations.of(context)!.intervention_phase_duration,
           ),
@@ -122,6 +126,7 @@ class StudyDetailsView extends StatelessWidget {
           ),
         ),
         ListTile(
+          key: const ValueKey('study_length_tile'),
           title: Text(AppLocalizations.of(context)!.study_length),
           subtitle: Text('$studyLength ${AppLocalizations.of(context)!.days}'),
           leading: Icon(
@@ -132,6 +137,7 @@ class StudyDetailsView extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         ContactWidget(
+          key: const ValueKey('study_publisher_contact'),
           contact: study!.contact,
           title: AppLocalizations.of(context)!.study_publisher,
           color: theme.colorScheme.secondary,

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -29,12 +29,14 @@ Future<void> showAppOutdatedDialog(BuildContext context) async {
   await showDialog(
     context: context,
     builder: (context) => AlertDialog(
+      key: const ValueKey('app_outdated_dialog'),
       title: Text(
         AppLocalizations.of(context)!.study_selection_unsupported_title,
       ),
       content: Text(AppLocalizations.of(context)!.study_selection_unsupported),
       actions: [
         TextButton(
+          key: const ValueKey('dialog_ok'),
           onPressed: () => Navigator.pop(context),
           child: const Text("OK"),
         ),
@@ -47,10 +49,12 @@ Future<void> showStudyClosedDialog(BuildContext context) async {
   await showDialog(
     context: context,
     builder: (context) => AlertDialog(
+      key: const ValueKey('study_closed_dialog'),
       title: Text(AppLocalizations.of(context)!.study_selection_closed_title),
       content: Text(AppLocalizations.of(context)!.study_selection_closed),
       actions: [
         TextButton(
+          key: const ValueKey('dialog_ok'),
           onPressed: () => Navigator.pop(context),
           child: const Text("OK"),
         ),
@@ -171,6 +175,7 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
                           });
                         }
                         return ListView.builder(
+                          key: const ValueKey('study_selection_list'),
                           itemCount: studies.length,
                           itemBuilder: (context, index) {
                             final study = studies[index];
@@ -196,6 +201,7 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
               Padding(
                 padding: const EdgeInsets.all(8),
                 child: OutlinedButton.icon(
+                  key: const ValueKey('study_selection_invite_code'),
                   icon: Icon(MdiIcons.key),
                   onPressed: () async {
                     await showDialog(
@@ -236,8 +242,10 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
 
   @override
   Widget build(BuildContext context) => AlertDialog(
+    key: const ValueKey('invite_code_dialog'),
     title: Text(AppLocalizations.of(context)!.private_study_invite_code),
     content: TextFormField(
+      key: const ValueKey('invite_code_field'),
       controller: _controller,
       validator: (_) => _errorMessage,
       autovalidateMode: AutovalidateMode.always,
@@ -247,6 +255,7 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
     ),
     actions: [
       OutlinedButton.icon(
+        key: const ValueKey('invite_code_submit'),
         icon: const Icon(Icons.arrow_forward),
         label: Text(AppLocalizations.of(context)!.next),
         onPressed: () async {

--- a/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
+++ b/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
@@ -82,6 +82,7 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
         ),
         if (response != null)
           ElevatedButton.icon(
+            key: const ValueKey('questionnaire_complete'),
             style: ButtonStyle(
               backgroundColor: WidgetStateProperty.all<Color>(Colors.green),
             ),

--- a/app/lib/widgets/bottom_onboarding_navigation.dart
+++ b/app/lib/widgets/bottom_onboarding_navigation.dart
@@ -12,6 +12,8 @@ class BottomOnboardingNavigation extends StatelessWidget {
   final Icon? nextIcon;
   final Icon? backIcon;
   final Widget? progress;
+  final Key? backButtonKey;
+  final Key? nextButtonKey;
 
   const BottomOnboardingNavigation({
     super.key,
@@ -25,6 +27,8 @@ class BottomOnboardingNavigation extends StatelessWidget {
     this.nextIcon,
     this.backIcon,
     this.progress,
+    this.backButtonKey,
+    this.nextButtonKey,
   });
 
   @override
@@ -40,6 +44,7 @@ class BottomOnboardingNavigation extends StatelessWidget {
               maintainAnimation: true,
               maintainState: true,
               child: TextButton(
+                key: backButtonKey,
                 onPressed: backEnabled
                     ? (onBack ?? () => Navigator.pop(context))
                     : null,
@@ -63,6 +68,7 @@ class BottomOnboardingNavigation extends StatelessWidget {
               maintainAnimation: true,
               maintainState: true,
               child: TextButton(
+                key: nextButtonKey,
                 onPressed: onNext,
                 child: Row(
                   children: [

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   fl_chart: ^1.2.0
   flutter:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
   flutter_file_dialog: ^3.0.3
   flutter_local_notifications: ^21.0.0
   flutter_localizations:

--- a/designer_v2/lib/common_views/form_buttons.dart
+++ b/designer_v2/lib/common_views/form_buttons.dart
@@ -36,6 +36,7 @@ class DismissButton extends StatelessWidget {
         }
       },
       child: SecondaryButton(
+        key: const ValueKey('form_dismiss_button'),
         text: text ?? tr.dialog_cancel,
         icon: null,
         //tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
@@ -58,6 +59,7 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
       builder: (context, form, child) {
         return retainSizeInAppBar(
           DismissButton(
+            key: const ValueKey('form_cancel_button'),
             onPressed: () => formViewModel.cancel().then((_) {
               if (context.mounted) Navigator.maybePop(context);
             }),
@@ -70,6 +72,7 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
       builder: (context, form, child) {
         return retainSizeInAppBar(
           PrimaryButton(
+            key: const ValueKey('form_save_button'),
             text: tr.dialog_save,
             tooltipDisabled:
                 "${tr.form_invalid_prompt}\n\n${formViewModel.form.validationErrorSummary}",
@@ -95,6 +98,7 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
       builder: (context, form, child) {
         return retainSizeInAppBar(
           DismissButton(
+            key: const ValueKey('form_close_button'),
             text: tr.dialog_close,
             onPressed: () => Navigator.maybePop(context),
           ),

--- a/designer_v2/lib/common_views/navbar_tabbed.dart
+++ b/designer_v2/lib/common_views/navbar_tabbed.dart
@@ -195,6 +195,7 @@ class _TabbedNavbarState<T extends NavbarTab>
     return Theme(
       data: theme.copyWith(splashColor: Colors.transparent),
       child: TabBar(
+        key: const ValueKey('navbar_tab_bar'),
         dividerColor: Colors.transparent,
         isScrollable: widget.isScrollable,
         labelPadding: widget.labelPadding,
@@ -230,6 +231,7 @@ class _TabbedNavbarState<T extends NavbarTab>
         0.0;
 
     return Container(
+      key: ValueKey('navbar_tab_${t.index}'),
       decoration: (!t.enabled)
           ? BoxDecoration(color: widget.disabledBackgroundColor)
           : null,

--- a/designer_v2/lib/driver_main.dart
+++ b/designer_v2/lib/driver_main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:studyu_designer_v2/main.dart' as app_main;
+
+Future<void> main() async {
+  enableFlutterDriverExtension();
+  await app_main.main();
+}

--- a/designer_v2/lib/features/auth/auth_form_fields.dart
+++ b/designer_v2/lib/features/auth/auth_form_fields.dart
@@ -36,6 +36,7 @@ class _EmailTextFieldState extends State<EmailTextField> {
         FormTableRow(
           labelStyle: const TextStyle(fontWeight: FontWeight.bold),
           input: ReactiveTextField(
+            key: const ValueKey('auth_email_field'),
             formControl: widget.formControl,
             formControlName: widget.formControlName,
             decoration: InputDecoration(
@@ -85,6 +86,7 @@ class _PasswordTextFieldState extends State<PasswordTextField> {
       rows: [
         FormTableRow(
           input: ReactiveTextField(
+            key: const ValueKey('auth_password_field'),
             formControl: widget.formControl,
             formControlName: widget.formControlName,
             obscureText: !passwordVisibility,
@@ -93,6 +95,7 @@ class _PasswordTextFieldState extends State<PasswordTextField> {
               labelText: widget.labelText,
               hintText: widget.hintText,
               suffixIcon: InkWell(
+                key: const ValueKey('auth_password_visibility_toggle'),
                 onTap: () =>
                     setState(() => passwordVisibility = !passwordVisibility),
                 focusNode: FocusNode(skipTraversal: true),

--- a/designer_v2/lib/features/auth/login_form_view.dart
+++ b/designer_v2/lib/features/auth/login_form_view.dart
@@ -24,9 +24,13 @@ class LoginForm extends FormConsumerRefWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        EmailTextField(formControl: controller.getEmailControl()),
+        EmailTextField(
+          key: const ValueKey('login_email'),
+          formControl: controller.getEmailControl(),
+        ),
         const SizedBox(height: 4.0),
         PasswordTextField(
+          key: const ValueKey('login_password'),
           formControl: controller.getPasswordControl(),
           onSubmitted: (_) => form.valid
               ? ref.read(authFormControllerProvider(formKey).notifier).signIn()
@@ -37,6 +41,7 @@ class LoginForm extends FormConsumerRefWidget {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Hyperlink(
+              key: const ValueKey('forgot_password_link'),
               text: tr.link_forgot_password,
               style: TextStyle(fontSize: theme.textTheme.bodySmall!.fontSize),
               onClick: () => ref
@@ -50,6 +55,7 @@ class LoginForm extends FormConsumerRefWidget {
           builder: (context, form, child) {
             return Center(
               child: PrimaryButton(
+                key: const ValueKey('login_button'),
                 icon: Icons.login,
                 text: tr.action_button_login,
                 isLoading: state.isLoading,
@@ -75,6 +81,7 @@ class LoginForm extends FormConsumerRefWidget {
             Text(tr.link_signup_description),
             const SizedBox(width: 4.0),
             Hyperlink(
+              key: const ValueKey('signup_link'),
               text: tr.link_signup,
               onClick: () =>
                   ref.read(routerProvider).dispatch(RoutingIntents.signup),

--- a/designer_v2/lib/features/auth/signup_form_view.dart
+++ b/designer_v2/lib/features/auth/signup_form_view.dart
@@ -28,13 +28,20 @@ class SignupForm extends FormConsumerRefWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        EmailTextField(formControl: controller.getEmailControl()),
-        //const SizedBox(height: 12.0),
-        const SizedBox(height: 4.0),
-        PasswordTextField(formControl: controller.getPasswordControl()),
+        EmailTextField(
+          key: const ValueKey('signup_email'),
+          formControl: controller.getEmailControl(),
+        ),
         //const SizedBox(height: 12.0),
         const SizedBox(height: 4.0),
         PasswordTextField(
+          key: const ValueKey('signup_password'),
+          formControl: controller.getPasswordControl(),
+        ),
+        //const SizedBox(height: 12.0),
+        const SizedBox(height: 4.0),
+        PasswordTextField(
+          key: const ValueKey('signup_password_confirm'),
           formControl: controller.getPasswordConfirmationControl(),
           labelText: tr.form_field_password_confirm,
           hintText: tr.form_field_password_confirm_hint,
@@ -95,6 +102,7 @@ class SignupForm extends FormConsumerRefWidget {
           builder: (context, form, child) {
             return Center(
               child: PrimaryButton(
+                key: const ValueKey('signup_button'),
                 text: tr.action_button_signup,
                 isLoading: state.isLoading,
                 enabled: form.valid,
@@ -119,6 +127,7 @@ class SignupForm extends FormConsumerRefWidget {
             Text(tr.link_login_description),
             const SizedBox(width: 4.0),
             Hyperlink(
+              key: const ValueKey('login_link'),
               text: tr.link_login,
               onClick: () =>
                   ref.read(routerProvider).dispatch(RoutingIntents.login),

--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -215,11 +215,13 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                 height: 36.0, // Fixed height for alignment
                 child: MediaQuery.of(context).size.width < 500
                     ? IconButton.filled(
+                        key: const ValueKey('new_study_compact_button'),
                         icon: const Icon(Icons.add),
                         onPressed: controller.onClickNewStudy,
                         tooltip: tr.action_button_new_study,
                       )
                     : PrimaryButton(
+                        key: const ValueKey('new_study_button'),
                         text: tr.action_button_new_study,
                         onPressed: controller.onClickNewStudy,
                       ),
@@ -253,6 +255,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                             isLabelVisible: isActive,
                             child: MediaQuery.of(context).size.width < 600
                                 ? IconButton.outlined(
+                                    key: const ValueKey('filter_toggle_button'),
                                     onPressed: () {
                                       if (controller.isOpen) {
                                         controller.close();
@@ -278,6 +281,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                                     ),
                                   )
                                 : OutlinedButton.icon(
+                                    key: const ValueKey(
+                                      'filter_toggle_button_labeled',
+                                    ),
                                     onPressed: () {
                                       if (controller.isOpen) {
                                         controller.close();
@@ -455,6 +461,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                       const SizedBox(width: 12),
                       if (MediaQuery.of(context).size.width < 900)
                         IconButton(
+                          key: const ValueKey('search_button'),
                           icon: const Icon(Icons.search),
                           onPressed: () {
                             showDialog(
@@ -463,6 +470,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                                 content: SizedBox(
                                   width: 400,
                                   child: Search(
+                                    key: const ValueKey('search_field'),
                                     searchController: state.searchController,
                                     hintText: tr.search,
                                     onQueryChanged: (query) =>
@@ -478,6 +486,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                           child: Container(
                             constraints: const BoxConstraints(maxWidth: 300),
                             child: Search(
+                              key: const ValueKey('search_field'),
                               searchController: state.searchController,
                               hintText: tr.search,
                               onQueryChanged: (query) =>

--- a/designer_v2/lib/features/dashboard/studies_table.dart
+++ b/designer_v2/lib/features/dashboard/studies_table.dart
@@ -235,12 +235,14 @@ class StudiesTable extends StatelessWidget {
             ),
             SizedBox(height: rowSpacing),
             ListView.builder(
+              key: const ValueKey('studies_table_rows'),
               itemCount: studies.length,
               itemExtent: (2 * itemPadding) + itemHeight + rowSpacing,
               shrinkWrap: true,
               itemBuilder: (context, index) {
                 final item = studies[index];
                 return StudiesTableItem(
+                  key: ValueKey('study_row_${item.id}'),
                   study: item,
                   columnSizes: columnDefinitionsMap.values.toList(),
                   actions: getActions(item),

--- a/designer_v2/lib/features/dashboard/studies_table_column_header.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_column_header.dart
@@ -33,6 +33,7 @@ class _StudiesTableColumnHeaderState extends State<StudiesTableColumnHeader> {
     final theme = Theme.of(context);
 
     return MouseEventsRegion(
+      key: ValueKey('studies_table_column_header_${widget.title}'),
       builder: (context, state) {
         return Row(
           mainAxisAlignment: widget.center

--- a/designer_v2/lib/features/dashboard/studies_table_item.dart
+++ b/designer_v2/lib/features/dashboard/studies_table_item.dart
@@ -81,6 +81,7 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
               ),
             ),
             child: InkWell(
+              key: ValueKey('study_row_ink_${widget.study.id}'),
               splashColor: Colors.transparent,
               onTap: () => widget.onTap?.call(widget.study),
               onHover: (hover) {
@@ -96,6 +97,7 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
                     widget.columnSizes[0].createContainer(
                       height: widget.itemHeight,
                       child: MouseEventsRegion(
+                        key: ValueKey('pin_icon_${widget.study.id}'),
                         onTap: () => widget.onPinnedChanged?.call(
                           widget.study,
                           !widget.isPinned,
@@ -229,6 +231,7 @@ class _StudiesTableItemState extends State<StudiesTableItem> {
 
     return Align(
       child: ActionPopUpMenuButton(
+        key: ValueKey('study_row_actions_${widget.study.id}'),
         actions: actions,
         triggerIconColor: ThemeConfig.bodyTextMuted(
           theme,

--- a/designer_v2/lib/features/study/study_scaffold.dart
+++ b/designer_v2/lib/features/study/study_scaffold.dart
@@ -243,6 +243,7 @@ class _StudyScaffoldState extends ConsumerState<StudyScaffold> {
           // enable re-rendering based on form validation status
           builder: (context, form, child) {
             return PrimaryButton(
+              key: const ValueKey('publish_button'),
               text: tr.action_button_study_launch,
               tooltipDisabled:
                   "${tr.form_invalid_prompt}\n\n${form.validationErrorSummary}",
@@ -271,6 +272,7 @@ class _StudyScaffoldState extends ConsumerState<StudyScaffold> {
           // enable re-rendering based on form validation status
           builder: (context, form, child) {
             return SecondaryButton(
+              key: const ValueKey('close_study_button'),
               text: tr.action_button_study_close,
               icon: null,
               onPressed: () => showStudyDialog(
@@ -289,6 +291,7 @@ class _StudyScaffoldState extends ConsumerState<StudyScaffold> {
     if (state.isSettingsEnabled) {
       actionButtons.add(
         IconButton(
+          key: const ValueKey('study_settings_button'),
           onPressed: controller.onSettingsPressed,
           icon: Icon(Icons.settings_rounded, size: theme.iconTheme.size),
           tooltip: tr.study_settings,
@@ -300,6 +303,7 @@ class _StudyScaffoldState extends ConsumerState<StudyScaffold> {
 
     actionButtons.add(
       ActionPopUpMenuButton(
+        key: const ValueKey('study_overflow_menu'),
         actions: state.studyActions,
         orientation: Axis.vertical,
         enabled: state.study.hasValue, // disable while study is loading

--- a/designer_v2/pubspec.yaml
+++ b/designer_v2/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_colorpicker: ^1.1.0
+  flutter_driver:
+    sdk: flutter
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^3.3.1

--- a/docs/test-keys.md
+++ b/docs/test-keys.md
@@ -1,0 +1,82 @@
+# UI Test Keys (MCP / Flutter Driver)
+
+This document defines naming conventions for `ValueKey`s used for UI automation in StudyU.
+
+## Why
+
+- Stable selectors for MCP (`ByValueKey`) and Flutter Driver
+- Less brittle than `ByText` (localization/copy changes)
+- Faster and more deterministic automation
+
+## Naming Convention
+
+- Use `snake_case` strings
+- Keep keys semantic and action-oriented
+- Prefer stable IDs for dynamic items
+
+Examples:
+
+- Static button: `ValueKey('welcome_get_started')`
+- Dynamic row item: `ValueKey('study_row_${item.id}')`
+- Dynamic card: `ValueKey('intervention_card_${intervention.id}')`
+
+## Scope Prefixes
+
+Use a screen/feature prefix for readability:
+
+- `welcome_*`
+- `onboarding_*`
+- `study_selection_*`
+- `eligibility_*`
+- `consent_*`
+- `dashboard_*`
+- `settings_*`
+- `task_*`
+- `filter_*`
+- `study_row_*`
+- `navbar_*`
+- `form_*`
+- `auth_*`
+
+## Current High-Value Keys
+
+### App (`app/`)
+
+- Welcome: `welcome_about`, `welcome_contact`, `welcome_faq`, `welcome_get_started`
+- Onboarding: `onboarding_back`, `onboarding_next`, `onboarding_done`
+- Terms: `terms_continue`, `terms_checkbox`, `privacy_checkbox`, `imprint_button`
+- Study selection: `study_selection_list`, `study_selection_invite_code`, `invite_code_dialog`, `invite_code_field`, `invite_code_submit`
+- Eligibility: `eligibility_screen`, `eligibility_pass_banner`, `eligibility_fail_banner`, `eligibility_back`, `eligibility_continue`
+- Consent: `consent_decline`, `consent_accept`, `consent_card_<index>`
+- Intervention selection: `intervention_selection_screen`, `intervention_selection_list`, `intervention_card_<id>`, `intervention_selection_continue`
+- Study/Journey overview: `study_overview_screen`, `study_overview_next`, `journey_overview_screen`, `journey_overview_next`
+- Dashboard: `dashboard_contact`, `dashboard_report`, `dashboard_menu`, `dashboard_next_day`, `finished_report_history`, `finished_study_selection`
+- Task: `questionnaire_complete`, `task_box_<taskId>`, `task_box_checkbox`
+- Settings: `settings_screen`, `settings_language_dropdown`, `settings_analytics_switch`, `settings_opt_out`, `settings_delete_data`, `opt_out_confirm`, `delete_data_confirm`
+
+### Designer (`designer_v2/`)
+
+- Auth: `login_email`, `login_password`, `login_button`, `signup_email`, `signup_password`, `signup_password_confirm`, `signup_button`, `auth_email_field`, `auth_password_field`
+- Dashboard table: `studies_table_rows`, `study_row_<id>`, `study_row_ink_<id>`, `pin_icon_<id>`, `study_row_actions_<id>`, `studies_table_column_header_<title>`
+- Filters/Search: `filter_toggle_button`, `filter_toggle_button_labeled`, `search_button`, `search_field`
+- Navigation: `navbar_tab_bar`, `navbar_tab_<index>`
+- Form actions: `form_cancel_button`, `form_save_button`, `form_close_button`, `form_dismiss_button`
+- Study actions: `publish_button`, `close_study_button`, `study_settings_button`, `study_overflow_menu`
+
+## Implementation Guidance
+
+- Add keys to **interactive** widgets first:
+  - buttons, tabs, row actions, menu triggers, form fields, dialog confirms
+- Keep keys stable across refactors
+- Avoid including localized text in key names
+- For repeated widgets, include unique stable identifiers (`id`, index as fallback)
+
+## MCP Usage
+
+Prefer:
+
+- `finderType: ByValueKey`
+
+Over:
+
+- `ByText` (fallback only)


### PR DESCRIPTION
## Description
Adds stable `ValueKey` selectors for MCP/UI automation across app onboarding, study onboarding, dashboard, and designer auth/dashboard flows. Also includes Flutter driver support entrypoints for app + designer and synchronized generated app localization updates.

Motivation: make automated UI interaction and testing reliable by avoiding text-based selectors.

## Testing Steps
1. Checkout `feat/devx-mcp-automation`.
2. Run `fvm exec melos run qualitycheck`.
3. Launch app and designer flows and verify key widgets are selectable via `ValueKey`.
4. (Optional) Run existing MCP/driver flows against onboarding and dashboard screens.
