### PR TITLE
fix: remove deprecated material_design_icons_flutter dependency

### DIFF
--- a/app/lib/screens/app_onboarding/app_outdated_screen.dart
+++ b/app/lib/screens/app_onboarding/app_outdated_screen.dart
@@ -16,10 +16,10 @@ class AppOutdatedScreen extends StatelessWidget {
     IconData? storeIcon;
     if (!kIsWeb && Platform.isAndroid) {
       storeUrl = playStoreUrl;
-      storeIcon = Icons.android;
+      storeIcon = Icons.shop;
     } else if (!kIsWeb && Platform.isIOS) {
       storeUrl = appstoreUrl;
-      storeIcon = Icons.apple;
+      storeIcon = Icons.shop;
     }
     return Scaffold(
       body: SafeArea(

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   intersperse: ^2.0.0
   intl: ^0.20.2
   introduction_screen: ^4.0.0
-  material_design_icons_flutter: ^7.0.7296
   package_info_plus: ^10.1.0
   path: ^1.9.1
   path_drawing: ^1.0.1

--- a/designer_v2/pubspec.yaml
+++ b/designer_v2/pubspec.yaml
@@ -31,7 +31,6 @@ dependencies:
   go_router: ^17.2.3
   intl: ^0.20.2
   material_color_utilities: ^0.13.0 # integration_test
-  material_design_icons_flutter: ^7.0.7296
   package_info_plus: ^10.1.0
   pointer_interceptor: ^0.10.1+2
   reactive_color_picker: ^2.2.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1173,14 +1173,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
-  material_design_icons_flutter:
-    dependency: transitive
-    description:
-      name: material_design_icons_flutter
-      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.7296"
   melos:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
## Description
Removes the remaining `material_design_icons_flutter` dependency after PR #834 migrated all imports. This package breaks compilation with Flutter 3.44 / Dart 3.12 because `IconData` was made `final` and `_MdiIconData extends IconData` is now illegal.

Changes:
- Remove `material_design_icons_flutter: ^7.0.7296` from `app/pubspec.yaml`
- Remove `material_design_icons_flutter: ^7.0.7296` from `designer_v2/pubspec.yaml`
- Regenerate `pubspec.lock` (package no longer resolved)

All imports and `MdiIcons.fromString` usages were already migrated to `flutter_material_design_icons` and `MdiIconsHelper` in PR #834.

## Testing Steps
1. Run `fvm exec melos run qualitycheck`
2. Run `cd app && fvm flutter test` — all 27 tests pass
3. Run `cd designer_v2 && fvm flutter test` — all 13 tests pass