### PR TITLE
fix(app): support manual release tag dispatch

### DIFF
--- a/.github/workflows/release_app.yml
+++ b/.github/workflows/release_app.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'studyu_app-v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and upload, for example studyu_app-v2.13.0'
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 concurrency:
   group: ${{ github.ref }}-github-release
@@ -20,11 +28,24 @@ jobs:
         with:
           workflowId: 'publish_pubdev.yml'
       - name: Get the tag name
-        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "$tag" =~ ^studyu_app-v.+$ ]]; then
+            echo "Release tag must match studyu_app-v*, got: $tag" >&2
+            exit 1
+          fi
+
+          echo "TAG=$tag" >> "$GITHUB_ENV"
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       - name: Prepare upload key
         run: |
           echo "$STUDYU_ANDROID_KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
@@ -33,7 +54,7 @@ jobs:
         env:
           STUDYU_ANDROID_KEYSTORE_BASE64: ${{ secrets.STUDYU_ANDROID_KEYSTORE_BASE64 }}
           STUDYU_KEY_PROPERTIES: ${{ secrets.STUDYU_KEY_PROPERTIES }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -45,21 +66,17 @@ jobs:
         run: flutter build apk --release --build-number ${{ github.run_number }}
         working-directory: ./app
       - name: Create Release
-        id: create_release
-        uses: shogo82148/actions-create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.TAG }}
-          release_name: ${{ env.TAG }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+          else
+            gh release create "$TAG" --title "$TAG" --target "$(git rev-parse HEAD)"
+          fi
       - name: Upload APK Asset
-        id: upload-release-asset-apk
-        uses: shogo82148/actions-upload-release-asset@v1
-        if: startsWith(github.ref, 'refs/tags/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./app/build/app/outputs/flutter-apk/app-release.apk
-          asset_name: studyu-${{ env.TAG }}.apk
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp ./app/build/app/outputs/flutter-apk/app-release.apk "studyu-$TAG.apk"
+          gh release upload "$TAG" "studyu-$TAG.apk" --clobber


### PR DESCRIPTION
## Description
Release workflow manual dispatch previously ran against the selected branch ref and derived `TAG` from `GITHUB_REF`, which made manual runs try to create invalid releases like `refs/heads/dev`. This updates the workflow so manual runs require an app release tag, checkout/build that exact tag, and upload the APK to that release. It also uses `actions/setup-java@v5` to address the Node.js 20 deprecation warning for setup-java.

## Visuals
No UI changes. Screenshot or video still required by repository checklist before merge.

## Testing Steps
- [x] `fvm exec melos run qualitycheck` passes
- [x] Re-pushed `studyu_app-v2.13.0` as a single tag push to trigger the release workflow
- [ ] Run manual `Github Release` workflow with tag input `studyu_app-v2.13.0` and verify APK upload if needed

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
- [ ] Screenshot or video of the changes attached
- [ ] Description links related issues