### PR TITLE
chore(app): update workflow action versions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,22 @@
 'core':
-  - 'core/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'core/**/*'
 'designer_v2':
-  - 'designer_v2/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'designer_v2/**/*'
 'app':
-  - 'app/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'app/**/*'
 'flutter_common':
-  - 'flutter_common/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'flutter_common/**/*'
 'dependencies':
-  - '**/pubspec.yaml'
-  - '**/pubspec.lock'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/pubspec.yaml'
+          - '**/pubspec.lock'
 'documentation':
-  - 'docs/**/*'
-  - '**/*.md'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**/*'
+          - '**/*.md'

--- a/.github/workflows/all_packages.yml
+++ b/.github/workflows/all_packages.yml
@@ -57,7 +57,7 @@ jobs:
           done
 
       - name: Commit changes if any
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore: Apply static analysis changes'
 

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -69,7 +69,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up java env
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -43,7 +43,7 @@ jobs:
           cp supabase/seed-ci.sql supabase/seed.sql
 
       - name: Set up Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 

--- a/.github/workflows/firebase-hosting-merge-dev.yml
+++ b/.github/workflows/firebase-hosting-merge-dev.yml
@@ -19,6 +19,7 @@ on:
       - '.firebaserc'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   MELOS_SDK_PATH: 'auto'
 
 concurrency:
@@ -33,7 +34,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Init workspace

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -19,6 +19,7 @@ on:
       - '.firebaserc'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   MELOS_SDK_PATH: 'auto'
 
 concurrency:
@@ -37,7 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Init workspace

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,6 +15,7 @@ on:
       - '.firebaserc'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   MELOS_SDK_PATH: 'auto'
 
 concurrency:
@@ -30,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Init workspace

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,6 +32,6 @@ jobs:
             done
 
         - name: Commit changes if any
-          uses: stefanzweifel/git-auto-commit-action@v6
+          uses: stefanzweifel/git-auto-commit-action@v7
           with:
             commit_message: 'lint: Apply final newline changes'

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: MegaLinter reports
@@ -102,7 +102,7 @@ jobs:
       # Create pull request if applicable
       # (for now works only on PR from same repository, not from forks)
       - name: Create Pull Request with applied fixes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         id: cpr
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
@@ -158,7 +158,7 @@ jobs:
         run: sudo chown -Rc $UID .git/
 
       - name: Commit and push applied linter fixes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
           (

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
   add-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v6
         with:
           sync-labels: true # allow removing labels when changes are reverted
           dot: true # have ** include hidden files as well
@@ -28,4 +28,4 @@ jobs:
     if: github.event.action == 'opened' || github.event.action == 'reopened'
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.2
+      - uses: toshimaru/auto-author-assign@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,4 +28,4 @@ jobs:
     if: github.event.action == 'opened' || github.event.action == 'reopened'
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v3
+      - uses: toshimaru/auto-author-assign@v3.0.2

--- a/.github/workflows/ready_to_merge.yml
+++ b/.github/workflows/ready_to_merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is ready to merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Define a list of workflows that need to finish successfully if run before merging  

--- a/.github/workflows/supabase-test.yml
+++ b/.github/workflows/supabase-test.yml
@@ -32,7 +32,7 @@ jobs:
           cp supabase/seed-ci.sql supabase/seed.sql
 
       - name: Set up Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 


### PR DESCRIPTION
## Description
Updates GitHub Actions workflow dependencies to avoid deprecated Node.js 20 action runtimes across StudyU workflows.

Changes include:
- Bump Node 24-compatible action versions for GitHub Script, Labeler, Supabase CLI setup, setup-node, setup-java, upload-artifact, git-auto-commit, create-pull-request, and auto-author-assign.
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to Firebase Hosting workflows because `FirebaseExtended/action-hosting-deploy@v0` does not currently provide a Node 24-compatible release.

## Testing Steps
1. `fvm install`
2. `fvm exec melos run qualitycheck`
3. Ruby YAML parse check for `.github/workflows/*.yml`
4. Grep verification confirmed no old requested Node 20 action refs remain.

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes