### PR TITLE
fix(designer): style and order dialog actions for consistent UX

### DIFF
--- a/designer_v2/lib/common_views/action_inline_menu.dart
+++ b/designer_v2/lib/common_views/action_inline_menu.dart
@@ -46,7 +46,7 @@ class ActionMenuInline extends StatelessWidget {
             return IconButton(
               padding: EdgeInsets.zero,
               splashRadius: splashRadius,
-              onPressed: () => action.onExecute(),
+              onPressed: () => action.execute(context),
               iconSize: iconSize ?? theme.iconTheme.size ?? 16.0,
               icon: Icon(
                 action.icon,

--- a/designer_v2/lib/common_views/action_popup_menu.dart
+++ b/designer_v2/lib/common_views/action_popup_menu.dart
@@ -91,7 +91,8 @@ class ActionPopUpMenuButton extends StatelessWidget {
       elevation: elevation,
       splashRadius: splashRadius,
       position: position,
-      onSelected: (action) => action is ModelAction ? action.onExecute() : null,
+      onSelected: (action) =>
+          action is ModelAction ? action.execute(context) : null,
       itemBuilder: (BuildContext context) {
         final textTheme = theme.textTheme.labelMedium!;
         final List<PopupMenuEntry> popupList = [];

--- a/designer_v2/lib/common_views/confirmation_dialog.dart
+++ b/designer_v2/lib/common_views/confirmation_dialog.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:studyu_designer_v2/common_views/dialog.dart';
+import 'package:studyu_designer_v2/common_views/primary_button.dart';
+import 'package:studyu_designer_v2/common_views/secondary_button.dart';
+import 'package:studyu_designer_v2/common_views/text_paragraph.dart';
+
+class ConfirmationDialogAction {
+  const ConfirmationDialogAction({
+    required this.label,
+    required this.onPressed,
+    this.isDestructive = false,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final bool isDestructive;
+}
+
+class StandardConfirmationDialog extends StatelessWidget {
+  const StandardConfirmationDialog({
+    required this.title,
+    required this.actions,
+    this.message,
+    this.customContent,
+    this.icon,
+    super.key,
+  });
+
+  final String title;
+  final String? message;
+  final Widget? customContent;
+  final IconData? icon;
+  final List<ConfirmationDialogAction> actions;
+
+  bool get isDestructive => actions.any((action) => action.isDestructive);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final severityColor = theme.colorScheme.error;
+
+    return StandardDialog(
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, color: isDestructive ? severityColor : null),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: SelectableText(
+              title,
+              style: theme.textTheme.displaySmall?.copyWith(
+                fontWeight: FontWeight.normal,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body:
+          customContent ??
+          (message == null
+              ? const SizedBox.shrink()
+              : TextParagraph(text: message)),
+      actionButtons: [
+        for (final (index, action) in actions.indexed)
+          if (action.isDestructive)
+            PrimaryButton(
+              onPressed: action.onPressed,
+              text: action.label,
+              icon: null,
+              backgroundColor: severityColor,
+              foregroundColor: Colors.white,
+              minimumSize: const Size(120, 40),
+            )
+          else if (isDestructive)
+            SecondaryButton(
+              onPressed: action.onPressed,
+              text: action.label,
+              icon: null,
+              minimumSize: const Size(120, 40),
+            )
+          else if (index == 0)
+            PrimaryButton(
+              onPressed: action.onPressed,
+              text: action.label,
+              icon: null,
+              minimumSize: const Size(120, 40),
+            )
+          else
+            SecondaryButton(
+              onPressed: action.onPressed,
+              text: action.label,
+              icon: null,
+              minimumSize: const Size(120, 40),
+            ),
+      ],
+      maxWidth: 500,
+      minHeight: 0,
+    );
+  }
+}

--- a/designer_v2/lib/common_views/dialog.dart
+++ b/designer_v2/lib/common_views/dialog.dart
@@ -103,7 +103,7 @@ class StandardDialog extends StatelessWidget {
                     else
                       const SizedBox.shrink(),
                     Expanded(child: SingleChildScrollView(child: body)),
-                    SizedBox(height: padding.bottom * 3 / 4),
+                    SizedBox(height: padding.bottom),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: withSpacing(actionButtons, spacing: 8.0),

--- a/designer_v2/lib/common_views/primary_button.dart
+++ b/designer_v2/lib/common_views/primary_button.dart
@@ -17,6 +17,8 @@ class PrimaryButton extends StatefulWidget {
       vertical: 8.0,
     ),
     this.minimumSize,
+    this.backgroundColor,
+    this.foregroundColor,
     super.key,
   });
 
@@ -47,6 +49,9 @@ class PrimaryButton extends StatefulWidget {
 
   final Size? minimumSize;
 
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+
   @override
   State<PrimaryButton> createState() => _PrimaryButtonState();
 }
@@ -58,8 +63,8 @@ class _PrimaryButtonState extends State<PrimaryButton> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final primaryStyle = ElevatedButton.styleFrom(
-      foregroundColor: theme.colorScheme.onPrimary,
-      backgroundColor: theme.colorScheme.primary,
+      foregroundColor: widget.foregroundColor ?? theme.colorScheme.onPrimary,
+      backgroundColor: widget.backgroundColor ?? theme.colorScheme.primary,
       minimumSize: widget.minimumSize,
     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0));
 

--- a/designer_v2/lib/common_views/secondary_button.dart
+++ b/designer_v2/lib/common_views/secondary_button.dart
@@ -20,14 +20,23 @@ class SecondaryButton extends StatelessWidget {
     this.icon = Icons.add,
     this.isLoading = false,
     this.onPressed,
+    this.foregroundColor,
+    this.borderColor,
+    this.minimumSize,
     super.key,
   });
+
+  final Color? foregroundColor;
+  final Color? borderColor;
+  final Size? minimumSize;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final secondaryStyle = OutlinedButton.styleFrom(
-      side: BorderSide(color: theme.colorScheme.primary),
+      foregroundColor: foregroundColor ?? theme.colorScheme.primary,
+      side: BorderSide(color: borderColor ?? theme.colorScheme.primary),
+      minimumSize: minimumSize,
     );
 
     if (icon != null) {

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_controller.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_controller.dart
@@ -142,6 +142,7 @@ class EnrollmentFormViewModel extends FormViewModel<EnrollmentFormData>
     final actions = questionFormViewModels.availableActions(
       model,
       onEdit: onSelectItem,
+      confirmationSubject: tr.dialog_subject_screener_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -150,6 +151,7 @@ class EnrollmentFormViewModel extends FormViewModel<EnrollmentFormData>
   List<ModelAction> availablePopupActions(ScreenerQuestionFormViewModel model) {
     final actions = questionFormViewModels.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_screener_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -160,6 +162,7 @@ class EnrollmentFormViewModel extends FormViewModel<EnrollmentFormData>
   ) {
     final actions = questionFormViewModels.availableInlineActions(
       model,
+      confirmationSubject: tr.dialog_subject_screener_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -317,6 +320,7 @@ class EnrollmentFormConsentItemDelegate
   List<ModelAction> availableActions(ConsentItemFormViewModel model) {
     final actions = formViewModels.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_consent_item,
       isReadOnly: owner.isReadonly,
     );
     return withIcons(actions, modelActionIcons);

--- a/designer_v2/lib/features/design/interventions/intervention_form_controller.dart
+++ b/designer_v2/lib/features/design/interventions/intervention_form_controller.dart
@@ -149,6 +149,7 @@ class InterventionFormViewModel
     final actions = tasksCollection.availableActions(
       model,
       onEdit: onSelectItem,
+      confirmationSubject: tr.dialog_subject_intervention_task,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -157,6 +158,7 @@ class InterventionFormViewModel
   List<ModelAction> availablePopupActions(InterventionTaskFormViewModel model) {
     final actions = tasksCollection.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_intervention_task,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -167,6 +169,7 @@ class InterventionFormViewModel
   ) {
     final actions = tasksCollection.availableInlineActions(
       model,
+      confirmationSubject: tr.dialog_subject_intervention_task,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);

--- a/designer_v2/lib/features/design/interventions/interventions_form_controller.dart
+++ b/designer_v2/lib/features/design/interventions/interventions_form_controller.dart
@@ -124,6 +124,7 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
     final actions = interventionsCollection.availableActions(
       model,
       onEdit: onSelectItem,
+      confirmationSubject: tr.dialog_subject_intervention,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -132,6 +133,7 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
   List<ModelAction> availablePopupActions(InterventionFormViewModel model) {
     final actions = interventionsCollection.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_intervention,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -140,6 +142,7 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
   List<ModelAction> availableInlineActions(InterventionFormViewModel model) {
     final actions = interventionsCollection.availableInlineActions(
       model,
+      confirmationSubject: tr.dialog_subject_intervention,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);

--- a/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
@@ -112,6 +112,7 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
     final actions = surveyMeasurementFormViewModels.availableActions(
       model,
       onEdit: onSelectItem,
+      confirmationSubject: tr.dialog_subject_survey,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -122,6 +123,7 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
   ) {
     final actions = surveyMeasurementFormViewModels.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_survey,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -132,6 +134,7 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
   ) {
     final actions = surveyMeasurementFormViewModels.availableInlineActions(
       model,
+      confirmationSubject: tr.dialog_subject_survey,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
@@ -143,6 +143,7 @@ class MeasurementSurveyFormViewModel
     final actions = questionFormViewModels.availableActions(
       model,
       onEdit: onSelectItem,
+      confirmationSubject: tr.dialog_subject_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -151,6 +152,7 @@ class MeasurementSurveyFormViewModel
   List<ModelAction> availablePopupActions(QuestionFormViewModel model) {
     final actions = questionFormViewModels.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);
@@ -159,6 +161,7 @@ class MeasurementSurveyFormViewModel
   List<ModelAction> availableInlineActions(QuestionFormViewModel model) {
     final actions = questionFormViewModels.availableInlineActions(
       model,
+      confirmationSubject: tr.dialog_subject_question,
       isReadOnly: isReadonly,
     );
     return withIcons(actions, modelActionIcons);

--- a/designer_v2/lib/features/design/reports/reports_form_controller.dart
+++ b/designer_v2/lib/features/design/reports/reports_form_controller.dart
@@ -11,6 +11,7 @@ import 'package:studyu_designer_v2/features/forms/form_view_model.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model_collection.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model_collection_actions.dart';
 import 'package:studyu_designer_v2/features/study/study_test_app_routes.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/repositories/api_client.dart';
 import 'package:studyu_designer_v2/routing/router_config.dart';
 import 'package:studyu_designer_v2/routing/router_intent.dart';
@@ -220,6 +221,7 @@ class ReportFormItemDelegate
   List<ModelAction> availableActions(ReportItemFormViewModel model) {
     final actions = formViewModelCollection.availablePopupActions(
       model,
+      confirmationSubject: tr.dialog_subject_report_section,
       isReadOnly: owner.isReadonly,
     );
     final modalAction = ModelAction(

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -914,10 +914,14 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
       ModelAction(
         type: ModelActionType.remove,
         label: ModelActionType.remove.string,
+        confirmation: ModelActionConfirmations.remove(
+          subject: tr.dialog_subject_answer_option,
+        ),
         onExecute: () {
           final controlIdx = answerOptionsArray.controls.indexOf(model);
           answerOptionsArray.removeAt(controlIdx);
         },
+        isDestructive: true,
         isAvailable: isNotReadonly,
       ),
     ].where((action) => action.isAvailable).toList();

--- a/designer_v2/lib/features/forms/form_view_model_collection_actions.dart
+++ b/designer_v2/lib/features/forms/form_view_model_collection_actions.dart
@@ -1,5 +1,6 @@
 import 'package:studyu_designer_v2/features/forms/form_data.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model_collection.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/utils/model_action.dart';
 import 'package:studyu_designer_v2/utils/typings.dart';
 
@@ -17,6 +18,7 @@ extension FormViewModelCollectionActions<
     VoidCallbackOn<T>? onEdit,
     VoidCallbackOn<T>? onDuplicate,
     VoidCallbackOn<T>? onDelete,
+    String? confirmationSubject,
     bool isReadOnly = false,
   }) {
     final actions = [
@@ -43,6 +45,9 @@ extension FormViewModelCollectionActions<
         type: ModelActionType.delete,
         label: ModelActionType.delete.string,
         isDestructive: true,
+        confirmation: ModelActionConfirmations.delete(
+          subject: confirmationSubject ?? tr.dialog_subject_item,
+        ),
         onExecute: (onDelete != null)
             ? () => onDelete(formViewModel)
             : () {
@@ -60,20 +65,24 @@ extension FormViewModelCollectionActions<
 
   List<ModelAction> availablePopupActions(
     T formViewModel, {
+    String? confirmationSubject,
     bool isReadOnly = false,
   }) {
     return availableActions(
       formViewModel,
+      confirmationSubject: confirmationSubject,
       isReadOnly: isReadOnly,
     ).where((action) => action.type != ModelActionType.edit).toList();
   }
 
   List<ModelAction> availableInlineActions(
     T formViewModel, {
+    String? confirmationSubject,
     bool isReadOnly = false,
   }) {
     return availableActions(
       formViewModel,
+      confirmationSubject: confirmationSubject,
       isReadOnly: isReadOnly,
     ).where((action) => action.type == ModelActionType.edit).toList();
   }

--- a/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
+++ b/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
@@ -14,23 +14,25 @@ class UnsavedChangesDialog extends StatelessWidget {
       titleText: tr.dialog_unsaved_changes_title,
       body: TextParagraph(text: tr.dialog_unsaved_changes_description),
       actionButtons: [
-        PrimaryButton(
-          onPressed: () {
-            Navigator.pop(context, false);
-          },
-          text: tr.dialog_action_unsaved_changes_stay,
-          icon: null,
-        ),
         SecondaryButton(
           onPressed: () {
             Navigator.pop(context, true);
           },
           text: tr.dialog_action_unsaved_changes_discard,
           icon: null,
+          minimumSize: const Size(120, 40),
+        ),
+        PrimaryButton(
+          onPressed: () {
+            Navigator.pop(context, false);
+          },
+          text: tr.dialog_action_unsaved_changes_stay,
+          icon: null,
+          minimumSize: const Size(120, 40),
         ),
       ],
       maxWidth: 500,
-      minHeight: 225,
+      minHeight: 0,
     );
   }
 }

--- a/designer_v2/lib/localization/app_de.arb
+++ b/designer_v2/lib/localization/app_de.arb
@@ -135,6 +135,42 @@
   "dialog_study_close_description": "Bist du sicher, dass die Teilnahme an der Studie geschlossen werden soll? Dadurch können keine neuen Teilnehmer mehr aufgenommen werden. Bereits eingeschriebene Teilnehmer werden die Studie weiterhin durchführen können. Das Schließen einer Studie kann nicht rückgängig gemacht werden.",
   "dialog_study_delete_title": "Dauerhaft löschen?",
   "dialog_study_delete_description": "Bist du sicher, dass die Studie gelöscht werden soll? Die Studie und alle gesammelten Daten gehen dabei unwiderruflich verloren.",
+  "dialog_delete_title": "{subject} löschen?",
+  "@dialog_delete_title": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_delete_description": "Bist du sicher, dass dieses {subject} gelöscht werden soll? Diese Aktion kann nicht rückgängig gemacht werden.",
+  "@dialog_delete_description": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_remove_title": "{subject} entfernen?",
+  "@dialog_remove_title": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_remove_description": "Bist du sicher, dass diese {subject} entfernt werden soll? Diese Aktion kann nicht rückgängig gemacht werden.",
+  "@dialog_remove_description": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_subject_study": "Studie",
+  "dialog_subject_item": "Element",
+  "dialog_subject_question": "Frage",
+  "dialog_subject_screener_question": "Screening-Frage",
+  "dialog_subject_answer_option": "Antwortoption",
+  "dialog_subject_intervention": "Intervention",
+  "dialog_subject_intervention_task": "Interventionsaufgabe",
+  "dialog_subject_survey": "Umfrage",
+  "dialog_subject_consent_item": "Einwilligungspunkt",
+  "dialog_subject_report_section": "Berichtsabschnitt",
+  "dialog_subject_invite_code": "Teilnahmecode",
+  "dialog_subject_fitbit_credentials": "Fitbit-Zugangsdaten",
   "@__________________STUDYPAGE_DESIGN_SHARED__________________": {},
   "form_question_create": "Neue Frage",
   "form_question_edit": "Frage bearbeiten",

--- a/designer_v2/lib/localization/app_de.arb
+++ b/designer_v2/lib/localization/app_de.arb
@@ -141,7 +141,7 @@
       "subject": {}
     }
   },
-  "dialog_delete_description": "Bist du sicher, dass dieses {subject} gelöscht werden soll? Diese Aktion kann nicht rückgängig gemacht werden.",
+  "dialog_delete_description": "Diese Aktion kann nicht rückgängig gemacht werden und löscht dieses {subject} dauerhaft.",
   "@dialog_delete_description": {
     "placeholders": {
       "subject": {}
@@ -816,8 +816,8 @@
   "iconpicker_nonempty_prompt": "Icon auswählen",
   "iconpicker_empty_prompt": "Icon auswählen",
   "iconpicker_dialog_title": "Icon auswählen",
-  "dialog_unsaved_changes_title": "Zurück und Änderungen verwerfen?",
-  "dialog_unsaved_changes_description": "Du hast Änderungen vorgenommen, die noch nicht gespeichert wurden & verloren gehen, wenn du zurückgehst. Wenn du die Änderungen beibehalten möchtest, musst du sie vorher speichern.",
+  "dialog_unsaved_changes_title": "Ungespeicherte Änderungen verwerfen?",
+  "dialog_unsaved_changes_description": "Wenn du jetzt gehst, werden deine letzten Änderungen dauerhaft gelöscht.",
   "dialog_action_unsaved_changes_stay": "Hier bleiben",
   "dialog_action_unsaved_changes_discard": "Änderungen verwerfen",
   "under_construction": "Noch in Arbeit",

--- a/designer_v2/lib/localization/app_en.arb
+++ b/designer_v2/lib/localization/app_en.arb
@@ -143,7 +143,7 @@
       "subject": {}
     }
   },
-  "dialog_delete_description": "Are you sure you want to delete this {subject}? This action cannot be undone.",
+  "dialog_delete_description": "This action cannot be undone and will permanently remove this {subject}.",
   "@dialog_delete_description": {
     "placeholders": {
       "subject": {}
@@ -816,8 +816,8 @@
   "iconpicker_nonempty_prompt": "Change icon",
   "iconpicker_empty_prompt": "Pick an icon",
   "iconpicker_dialog_title": "Pick an icon",
-  "dialog_unsaved_changes_title": "Go back and discard changes?",
-  "dialog_unsaved_changes_description": "There are unsaved changes that will be lost when you go back. If you want to keep your changes, you need to save your work before going back.",
+  "dialog_unsaved_changes_title": "Discard unsaved changes?",
+  "dialog_unsaved_changes_description": "If you leave now, your recent changes will be permanently lost.",
   "dialog_action_unsaved_changes_stay": "Stay",
   "dialog_action_unsaved_changes_discard": "Discard changes",
   "under_construction": "Under construction",

--- a/designer_v2/lib/localization/app_en.arb
+++ b/designer_v2/lib/localization/app_en.arb
@@ -137,6 +137,42 @@
   "dialog_study_close_description": "Are you sure that you want to stop new enrollments for this study? New participants can no longer join, but those who are already enrolled can still continue. This action cannot be undone.",
   "dialog_study_delete_title": "Permanently delete?",
   "dialog_study_delete_description": "Are you sure you want to delete this study? You will permanently lose the study and all data that has been collected.",
+  "dialog_delete_title": "Delete {subject}?",
+  "@dialog_delete_title": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_delete_description": "Are you sure you want to delete this {subject}? This action cannot be undone.",
+  "@dialog_delete_description": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_remove_title": "Remove {subject}?",
+  "@dialog_remove_title": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_remove_description": "Are you sure you want to remove this {subject}? This action cannot be undone.",
+  "@dialog_remove_description": {
+    "placeholders": {
+      "subject": {}
+    }
+  },
+  "dialog_subject_study": "study",
+  "dialog_subject_item": "item",
+  "dialog_subject_question": "question",
+  "dialog_subject_screener_question": "screener question",
+  "dialog_subject_answer_option": "answer option",
+  "dialog_subject_intervention": "intervention",
+  "dialog_subject_intervention_task": "intervention task",
+  "dialog_subject_survey": "survey",
+  "dialog_subject_consent_item": "consent item",
+  "dialog_subject_report_section": "report section",
+  "dialog_subject_invite_code": "invite code",
+  "dialog_subject_fitbit_credentials": "fitbit credentials",
   "@__________________STUDYPAGE_DESIGN_SHARED__________________": {},
   "form_question_create": "New Question",
   "form_question_edit": "Edit Question",

--- a/designer_v2/lib/localization/app_localizations.dart
+++ b/designer_v2/lib/localization/app_localizations.dart
@@ -836,6 +836,102 @@ abstract class AppLocalizations {
   /// **'Are you sure you want to delete this study? You will permanently lose the study and all data that has been collected.'**
   String get dialog_study_delete_description;
 
+  /// No description provided for @dialog_delete_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {subject}?'**
+  String dialog_delete_title(Object subject);
+
+  /// No description provided for @dialog_delete_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to delete this {subject}? This action cannot be undone.'**
+  String dialog_delete_description(Object subject);
+
+  /// No description provided for @dialog_remove_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove {subject}?'**
+  String dialog_remove_title(Object subject);
+
+  /// No description provided for @dialog_remove_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to remove this {subject}? This action cannot be undone.'**
+  String dialog_remove_description(Object subject);
+
+  /// No description provided for @dialog_subject_study.
+  ///
+  /// In en, this message translates to:
+  /// **'study'**
+  String get dialog_subject_study;
+
+  /// No description provided for @dialog_subject_item.
+  ///
+  /// In en, this message translates to:
+  /// **'item'**
+  String get dialog_subject_item;
+
+  /// No description provided for @dialog_subject_question.
+  ///
+  /// In en, this message translates to:
+  /// **'question'**
+  String get dialog_subject_question;
+
+  /// No description provided for @dialog_subject_screener_question.
+  ///
+  /// In en, this message translates to:
+  /// **'screener question'**
+  String get dialog_subject_screener_question;
+
+  /// No description provided for @dialog_subject_answer_option.
+  ///
+  /// In en, this message translates to:
+  /// **'answer option'**
+  String get dialog_subject_answer_option;
+
+  /// No description provided for @dialog_subject_intervention.
+  ///
+  /// In en, this message translates to:
+  /// **'intervention'**
+  String get dialog_subject_intervention;
+
+  /// No description provided for @dialog_subject_intervention_task.
+  ///
+  /// In en, this message translates to:
+  /// **'intervention task'**
+  String get dialog_subject_intervention_task;
+
+  /// No description provided for @dialog_subject_survey.
+  ///
+  /// In en, this message translates to:
+  /// **'survey'**
+  String get dialog_subject_survey;
+
+  /// No description provided for @dialog_subject_consent_item.
+  ///
+  /// In en, this message translates to:
+  /// **'consent item'**
+  String get dialog_subject_consent_item;
+
+  /// No description provided for @dialog_subject_report_section.
+  ///
+  /// In en, this message translates to:
+  /// **'report section'**
+  String get dialog_subject_report_section;
+
+  /// No description provided for @dialog_subject_invite_code.
+  ///
+  /// In en, this message translates to:
+  /// **'invite code'**
+  String get dialog_subject_invite_code;
+
+  /// No description provided for @dialog_subject_fitbit_credentials.
+  ///
+  /// In en, this message translates to:
+  /// **'fitbit credentials'**
+  String get dialog_subject_fitbit_credentials;
+
   /// No description provided for @form_question_create.
   ///
   /// In en, this message translates to:

--- a/designer_v2/lib/localization/app_localizations.dart
+++ b/designer_v2/lib/localization/app_localizations.dart
@@ -845,7 +845,7 @@ abstract class AppLocalizations {
   /// No description provided for @dialog_delete_description.
   ///
   /// In en, this message translates to:
-  /// **'Are you sure you want to delete this {subject}? This action cannot be undone.'**
+  /// **'This action cannot be undone and will permanently remove this {subject}.'**
   String dialog_delete_description(Object subject);
 
   /// No description provided for @dialog_remove_title.
@@ -3678,13 +3678,13 @@ abstract class AppLocalizations {
   /// No description provided for @dialog_unsaved_changes_title.
   ///
   /// In en, this message translates to:
-  /// **'Go back and discard changes?'**
+  /// **'Discard unsaved changes?'**
   String get dialog_unsaved_changes_title;
 
   /// No description provided for @dialog_unsaved_changes_description.
   ///
   /// In en, this message translates to:
-  /// **'There are unsaved changes that will be lost when you go back. If you want to keep your changes, you need to save your work before going back.'**
+  /// **'If you leave now, your recent changes will be permanently lost.'**
   String get dialog_unsaved_changes_description;
 
   /// No description provided for @dialog_action_unsaved_changes_stay.

--- a/designer_v2/lib/localization/app_localizations_de.dart
+++ b/designer_v2/lib/localization/app_localizations_de.dart
@@ -411,6 +411,62 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bist du sicher, dass die Studie gelöscht werden soll? Die Studie und alle gesammelten Daten gehen dabei unwiderruflich verloren.';
 
   @override
+  String dialog_delete_title(Object subject) {
+    return '$subject löschen?';
+  }
+
+  @override
+  String dialog_delete_description(Object subject) {
+    return 'Bist du sicher, dass dieses $subject gelöscht werden soll? Diese Aktion kann nicht rückgängig gemacht werden.';
+  }
+
+  @override
+  String dialog_remove_title(Object subject) {
+    return '$subject entfernen?';
+  }
+
+  @override
+  String dialog_remove_description(Object subject) {
+    return 'Bist du sicher, dass diese $subject entfernt werden soll? Diese Aktion kann nicht rückgängig gemacht werden.';
+  }
+
+  @override
+  String get dialog_subject_study => 'Studie';
+
+  @override
+  String get dialog_subject_item => 'Element';
+
+  @override
+  String get dialog_subject_question => 'Frage';
+
+  @override
+  String get dialog_subject_screener_question => 'Screening-Frage';
+
+  @override
+  String get dialog_subject_answer_option => 'Antwortoption';
+
+  @override
+  String get dialog_subject_intervention => 'Intervention';
+
+  @override
+  String get dialog_subject_intervention_task => 'Interventionsaufgabe';
+
+  @override
+  String get dialog_subject_survey => 'Umfrage';
+
+  @override
+  String get dialog_subject_consent_item => 'Einwilligungspunkt';
+
+  @override
+  String get dialog_subject_report_section => 'Berichtsabschnitt';
+
+  @override
+  String get dialog_subject_invite_code => 'Teilnahmecode';
+
+  @override
+  String get dialog_subject_fitbit_credentials => 'Fitbit-Zugangsdaten';
+
+  @override
   String get form_question_create => 'Neue Frage';
 
   @override

--- a/designer_v2/lib/localization/app_localizations_de.dart
+++ b/designer_v2/lib/localization/app_localizations_de.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -417,7 +418,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String dialog_delete_description(Object subject) {
-    return 'Bist du sicher, dass dieses $subject gelöscht werden soll? Diese Aktion kann nicht rückgängig gemacht werden.';
+    return 'Diese Aktion kann nicht rückgängig gemacht werden und löscht dieses $subject dauerhaft.';
   }
 
   @override
@@ -2167,11 +2168,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get iconpicker_dialog_title => 'Icon auswählen';
 
   @override
-  String get dialog_unsaved_changes_title => 'Zurück und Änderungen verwerfen?';
+  String get dialog_unsaved_changes_title =>
+      'Ungespeicherte Änderungen verwerfen?';
 
   @override
   String get dialog_unsaved_changes_description =>
-      'Du hast Änderungen vorgenommen, die noch nicht gespeichert wurden & verloren gehen, wenn du zurückgehst. Wenn du die Änderungen beibehalten möchtest, musst du sie vorher speichern.';
+      'Wenn du jetzt gehst, werden deine letzten Änderungen dauerhaft gelöscht.';
 
   @override
   String get dialog_action_unsaved_changes_stay => 'Hier bleiben';

--- a/designer_v2/lib/localization/app_localizations_en.dart
+++ b/designer_v2/lib/localization/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -410,7 +411,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String dialog_delete_description(Object subject) {
-    return 'Are you sure you want to delete this $subject? This action cannot be undone.';
+    return 'This action cannot be undone and will permanently remove this $subject.';
   }
 
   @override
@@ -2140,11 +2141,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get iconpicker_dialog_title => 'Pick an icon';
 
   @override
-  String get dialog_unsaved_changes_title => 'Go back and discard changes?';
+  String get dialog_unsaved_changes_title => 'Discard unsaved changes?';
 
   @override
   String get dialog_unsaved_changes_description =>
-      'There are unsaved changes that will be lost when you go back. If you want to keep your changes, you need to save your work before going back.';
+      'If you leave now, your recent changes will be permanently lost.';
 
   @override
   String get dialog_action_unsaved_changes_stay => 'Stay';

--- a/designer_v2/lib/localization/app_localizations_en.dart
+++ b/designer_v2/lib/localization/app_localizations_en.dart
@@ -404,6 +404,62 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to delete this study? You will permanently lose the study and all data that has been collected.';
 
   @override
+  String dialog_delete_title(Object subject) {
+    return 'Delete $subject?';
+  }
+
+  @override
+  String dialog_delete_description(Object subject) {
+    return 'Are you sure you want to delete this $subject? This action cannot be undone.';
+  }
+
+  @override
+  String dialog_remove_title(Object subject) {
+    return 'Remove $subject?';
+  }
+
+  @override
+  String dialog_remove_description(Object subject) {
+    return 'Are you sure you want to remove this $subject? This action cannot be undone.';
+  }
+
+  @override
+  String get dialog_subject_study => 'study';
+
+  @override
+  String get dialog_subject_item => 'item';
+
+  @override
+  String get dialog_subject_question => 'question';
+
+  @override
+  String get dialog_subject_screener_question => 'screener question';
+
+  @override
+  String get dialog_subject_answer_option => 'answer option';
+
+  @override
+  String get dialog_subject_intervention => 'intervention';
+
+  @override
+  String get dialog_subject_intervention_task => 'intervention task';
+
+  @override
+  String get dialog_subject_survey => 'survey';
+
+  @override
+  String get dialog_subject_consent_item => 'consent item';
+
+  @override
+  String get dialog_subject_report_section => 'report section';
+
+  @override
+  String get dialog_subject_invite_code => 'invite code';
+
+  @override
+  String get dialog_subject_fitbit_credentials => 'fitbit credentials';
+
+  @override
   String get form_question_create => 'New Question';
 
   @override

--- a/designer_v2/lib/repositories/fitbit_credentials_repository.dart
+++ b/designer_v2/lib/repositories/fitbit_credentials_repository.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/repositories/api_client.dart';
 import 'package:studyu_designer_v2/repositories/auth_repository.dart';
 import 'package:studyu_designer_v2/repositories/model_repository.dart';
@@ -72,6 +73,9 @@ class FitbitCredentialsRepository
       ModelAction(
         type: ModelActionType.delete,
         label: ModelActionType.delete.string,
+        confirmation: ModelActionConfirmations.delete(
+          subject: tr.dialog_subject_fitbit_credentials,
+        ),
         onExecute: () async {
           return await delete(getKey(model))
               .then(

--- a/designer_v2/lib/repositories/invite_code_repository.dart
+++ b/designer_v2/lib/repositories/invite_code_repository.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/repositories/api_client.dart';
 import 'package:studyu_designer_v2/repositories/auth_repository.dart';
 import 'package:studyu_designer_v2/repositories/model_repository.dart';
@@ -83,6 +84,9 @@ class InviteCodeRepository extends ModelRepository<StudyInvite>
       ModelAction(
         type: ModelActionType.delete,
         label: ModelActionType.delete.string,
+        confirmation: ModelActionConfirmations.delete(
+          subject: tr.dialog_subject_invite_code,
+        ),
         onExecute: () async {
           return await delete(getKey(model))
               .then(

--- a/designer_v2/lib/repositories/study_repository.dart
+++ b/designer_v2/lib/repositories/study_repository.dart
@@ -5,13 +5,13 @@ import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/domain/study.dart';
 import 'package:studyu_designer_v2/domain/study_export.dart';
 import 'package:studyu_designer_v2/features/analyze/study_export_zip.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/repositories/api_client.dart';
 import 'package:studyu_designer_v2/repositories/auth_repository.dart';
 import 'package:studyu_designer_v2/repositories/model_repository.dart';
 import 'package:studyu_designer_v2/routing/router.dart';
 import 'package:studyu_designer_v2/routing/router_intent.dart';
 import 'package:studyu_designer_v2/services/notification_service.dart';
-import 'package:studyu_designer_v2/services/notification_types.dart';
 import 'package:studyu_designer_v2/services/notifications.dart';
 import 'package:studyu_designer_v2/utils/model_action.dart';
 import 'package:studyu_designer_v2/utils/optimistic_update.dart';
@@ -226,21 +226,12 @@ class StudyRepository extends ModelRepository<Study>
       ModelAction(
         type: StudyActionType.delete,
         label: StudyActionType.delete.string,
-        onExecute: () {
-          return ref
-              .read(notificationServiceProvider)
-              .show(
-                Notifications
-                    .studyDeleteConfirmation, // TODO: more severe confirmation for running studies
-                actions: [
-                  NotificationAction(
-                    label: StudyActionType.delete.string,
-                    onSelect: onDeleteCallback,
-                    isDestructive: true,
-                  ),
-                ],
-              );
-        },
+        onExecute: onDeleteCallback,
+        confirmation: ModelActionConfirmations.delete(
+          subject: tr.dialog_subject_study,
+          title: tr.dialog_study_delete_title,
+          message: tr.dialog_study_delete_description,
+        ),
         isAvailable: model.canDelete(currentUser),
         isDestructive: true,
       ),

--- a/designer_v2/lib/services/notification_dispatcher.dart
+++ b/designer_v2/lib/services/notification_dispatcher.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:studyu_designer_v2/common_views/confirmation_dialog.dart';
 import 'package:studyu_designer_v2/localization/string_hardcoded.dart';
 import 'package:studyu_designer_v2/services/notification_service.dart';
 import 'package:studyu_designer_v2/services/notification_types.dart';
@@ -122,17 +121,17 @@ class _NotificationDispatcherState
     }
   }
 
-  AlertDialog _buildAlertDialog(
+  Widget _buildAlertDialog(
     AlertIntent notification,
     NavigatorState navigatorState,
   ) {
-    final textTheme = Theme.of(context).textTheme;
-
-    final List<Widget> actions = [];
+    final List<ConfirmationDialogAction> actions = [];
     if (notification.actions != null) {
       for (final action in notification.actions!) {
         actions.add(
-          TextButton(
+          ConfirmationDialogAction(
+            label: action.label,
+            isDestructive: action.isDestructive,
             onPressed: () {
               if (notification.dismissOnAction) {
                 // always pop & don't wait for [action.onSelect]
@@ -140,51 +139,18 @@ class _NotificationDispatcherState
               }
               action.onSelect();
             },
-            child: Text(
-              action.label,
-              style: (action.isDestructive)
-                  ? textTheme.labelLarge!.copyWith(color: Colors.redAccent)
-                  : textTheme.labelLarge!,
-            ),
           ),
         );
       }
     }
 
-    return AlertDialog(
-      title: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(notification.icon),
-          Text("️ ${notification.title}", style: textTheme.displaySmall),
-        ],
-      ),
-      content: ConstrainedBox(
-        constraints: BoxConstraints(
-          minWidth: 300,
-          maxWidth: math.max(300, MediaQuery.of(context).size.width * 0.33),
-        ),
-        child: Row(
-          children: [
-            Flexible(
-              child: notificationContent(
-                notification.message,
-                notification.customContent,
-              ),
-            ),
-          ],
-        ),
-      ),
+    return StandardConfirmationDialog(
+      title: notification.title,
+      message: notification.message,
+      customContent: notification.customContent,
+      icon: notification.icon,
       actions: actions,
     );
-  }
-
-  Widget notificationContent(String? message, Widget? customContent) {
-    if (customContent != null) {
-      return customContent;
-    } else {
-      return Text(message!);
-    }
   }
 
   SnackBar _buildSnackbar(

--- a/designer_v2/lib/utils/model_action.dart
+++ b/designer_v2/lib/utils/model_action.dart
@@ -1,12 +1,61 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
+
+typedef ModelActionHandler = FutureOr<void> Function();
+
+class ModelActionConfirmation {
+  const ModelActionConfirmation({
+    required this.title,
+    this.message,
+    this.confirmLabel,
+    this.cancelLabel,
+    this.icon,
+  });
+
+  final String title;
+  final String? message;
+  final String? confirmLabel;
+  final String? cancelLabel;
+  final IconData? icon;
+}
+
+class ModelActionConfirmations {
+  static ModelActionConfirmation delete({
+    required String subject,
+    String? title,
+    String? message,
+    IconData icon = Icons.delete_rounded,
+  }) {
+    return ModelActionConfirmation(
+      title: title ?? tr.dialog_delete_title(subject),
+      message: message ?? tr.dialog_delete_description(subject),
+      icon: icon,
+    );
+  }
+
+  static ModelActionConfirmation remove({
+    required String subject,
+    String? title,
+    String? message,
+    IconData icon = Icons.delete_outline_rounded,
+  }) {
+    return ModelActionConfirmation(
+      title: title ?? tr.dialog_remove_title(subject),
+      message: message ?? tr.dialog_remove_description(subject),
+      icon: icon,
+    );
+  }
+}
 
 class ModelAction<T> {
   final T type;
   final String label;
   IconData? icon;
   final String? tooltip;
-  final void Function() onExecute;
+  final ModelActionHandler onExecute;
+  final ModelActionConfirmation? confirmation;
   final bool isHeader;
   final bool isSeparator;
   final bool isAvailable;
@@ -18,6 +67,7 @@ class ModelAction<T> {
     required this.type,
     required this.label,
     required this.onExecute,
+    this.confirmation,
     this.isSeparator = false,
     this.isHeader = false, // Added default
     this.isAvailable = true,
@@ -44,6 +94,49 @@ class ModelAction<T> {
       onExecute: () {},
       isHeader: true,
     );
+  }
+
+  Future<void> execute(BuildContext context) async {
+    if (confirmation != null) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (confirmation!.icon != null) ...[
+                Icon(confirmation!.icon),
+                const SizedBox(width: 8),
+              ],
+              Flexible(child: Text(confirmation!.title)),
+            ],
+          ),
+          content: (confirmation!.message == null)
+              ? null
+              : Text(confirmation!.message!),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(confirmation!.cancelLabel ?? tr.dialog_cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(
+                confirmation!.confirmLabel ?? label,
+                style: isDestructive
+                    ? const TextStyle(color: Colors.redAccent)
+                    : null,
+              ),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) {
+        return;
+      }
+    }
+
+    await Future.sync(onExecute);
   }
 }
 

--- a/designer_v2/lib/utils/model_action.dart
+++ b/designer_v2/lib/utils/model_action.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:studyu_designer_v2/common_views/confirmation_dialog.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
 typedef ModelActionHandler = FutureOr<void> Function();
@@ -26,7 +27,7 @@ class ModelActionConfirmations {
     required String subject,
     String? title,
     String? message,
-    IconData icon = Icons.delete_rounded,
+    IconData? icon,
   }) {
     return ModelActionConfirmation(
       title: title ?? tr.dialog_delete_title(subject),
@@ -39,7 +40,7 @@ class ModelActionConfirmations {
     required String subject,
     String? title,
     String? message,
-    IconData icon = Icons.delete_outline_rounded,
+    IconData? icon,
   }) {
     return ModelActionConfirmation(
       title: title ?? tr.dialog_remove_title(subject),
@@ -100,33 +101,19 @@ class ModelAction<T> {
     if (confirmation != null) {
       final confirmed = await showDialog<bool>(
         context: context,
-        builder: (dialogContext) => AlertDialog(
-          title: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (confirmation!.icon != null) ...[
-                Icon(confirmation!.icon),
-                const SizedBox(width: 8),
-              ],
-              Flexible(child: Text(confirmation!.title)),
-            ],
-          ),
-          content: (confirmation!.message == null)
-              ? null
-              : Text(confirmation!.message!),
+        builder: (dialogContext) => StandardConfirmationDialog(
+          title: confirmation!.title,
+          message: confirmation!.message,
+          icon: confirmation!.icon,
           actions: [
-            TextButton(
+            ConfirmationDialogAction(
+              label: confirmation!.cancelLabel ?? tr.dialog_cancel,
               onPressed: () => Navigator.of(dialogContext).pop(false),
-              child: Text(confirmation!.cancelLabel ?? tr.dialog_cancel),
             ),
-            TextButton(
+            ConfirmationDialogAction(
+              label: confirmation!.confirmLabel ?? label,
+              isDestructive: isDestructive,
               onPressed: () => Navigator.of(dialogContext).pop(true),
-              child: Text(
-                confirmation!.confirmLabel ?? label,
-                style: isDestructive
-                    ? const TextStyle(color: Colors.redAccent)
-                    : null,
-              ),
             ),
           ],
         ),

--- a/designer_v2/test/utils/model_action_confirmation_dialog_test.dart
+++ b/designer_v2/test/utils/model_action_confirmation_dialog_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_designer_v2/common_views/dialog.dart';
+import 'package:studyu_designer_v2/localization/app_localizations_en.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/utils/model_action.dart';
+
+void main() {
+  setUpAll(() {
+    AppTranslation.setForTesting(AppLocalizationsEn());
+  });
+
+  testWidgets('model action confirmation uses standard dialog design', (
+    tester,
+  ) async {
+    final action = ModelAction<ModelActionType>(
+      type: ModelActionType.delete,
+      label: 'Delete',
+      isDestructive: true,
+      confirmation: ModelActionConfirmations.delete(subject: 'item'),
+      onExecute: () {},
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => action.execute(context),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(StandardDialog), findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('Delete item?'), findsOneWidget);
+    expect(find.text('Delete'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('destructive confirmation uses subtle cancel and filled delete', (
+    tester,
+  ) async {
+    final action = ModelAction<ModelActionType>(
+      type: ModelActionType.delete,
+      label: 'Delete',
+      isDestructive: true,
+      confirmation: ModelActionConfirmations.delete(subject: 'item'),
+      onExecute: () {},
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => action.execute(context),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.ancestor(
+        of: find.text('Cancel'),
+        matching: find.byType(OutlinedButton),
+      ),
+      findsOneWidget,
+    );
+
+    final deleteButtonFinder = find.ancestor(
+      of: find.text('Delete'),
+      matching: find.byType(ElevatedButton),
+    );
+    expect(deleteButtonFinder, findsOneWidget);
+
+    final button = tester.widget<ElevatedButton>(deleteButtonFinder);
+    final context = tester.element(find.byType(StandardDialog));
+    final errorColor = Theme.of(context).colorScheme.error;
+
+    expect(button.style?.backgroundColor?.resolve({}), errorColor);
+    expect(button.style?.foregroundColor?.resolve({}), Colors.white);
+  });
+}


### PR DESCRIPTION
## Description
This pull request addresses several critical UX/UI improvements in the StudyU Designer modal dialogs:
- Swaps the action buttons in the unsaved changes dialog to align the safe option ("Stay") as the primary filled button (on the right) and "Discard changes" as the secondary outlined button (on the left), preventing accidental data loss.
- Aligns destructive confirmation dialog actions (e.g. Study/Task Delete) by displaying "Cancel" as a secondary outlined button and "Delete" as a primary filled red button.
- Adds optional color and size customization to `PrimaryButton` and `SecondaryButton` to support flat custom colors and uniform sizes.
- Equalizes spacing and padding inside standard dialogs for symmetrical vertical margins and removes excessive empty space by letting them hug content height.
- Shortens and clarifies english and german copy for deletion prompts and unsaved changes warnings to reduce cognitive load.

## Visuals

### Before

<img width="636" height="220" alt="Screenshot 2026-06-11 at 10 03 44" src="https://github.com/user-attachments/assets/44e8e4f2-b700-4619-b715-a50e03d7717f" />

<img width="515" height="238" alt="Screenshot 2026-06-11 at 10 02 04" src="https://github.com/user-attachments/assets/05e597ca-1d47-4463-80c0-188c586f2e1c" />

### After

<img width="515" height="262" alt="Screenshot 2026-06-11 at 10 01 26" src="https://github.com/user-attachments/assets/1e19b40e-9b4e-4ef6-b131-9ef210547004" />

<img width="528" height="275" alt="Screenshot 2026-06-11 at 10 03 59" src="https://github.com/user-attachments/assets/5678fcac-ae7e-4cd9-ae64-1e05e45cb4dd" />

## Testing Steps
1. Open study designer. Make unsaved edits to a form and trigger navigation back to open the unsaved changes modal. Verify "Discard changes" (outlined) is on the left and "Stay" (filled blue) is on the right, with balanced widths and equal padding.
2. Attempt to delete a task or study. Verify "Cancel" (outlined blue) is on the left and "Delete" (flat filled red) is on the right, with matching widths and padding.
3. Run verification test suite:
   `fvm flutter test test/utils/model_action_confirmation_dialog_test.dart`
4. Ensure workspace quality check passes:
   `fvm exec melos run qualitycheck`

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
- [x] Screenshot or video of the changes attached