### PR TITLE
fix(app): initialize loading screen after dependencies

### DIFF
--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -27,11 +27,14 @@ class LoadingScreen extends StatefulWidget {
 class _LoadingScreenState extends State<LoadingScreen> {
   final IFrameHelper _iFrameHelper = IFrameHelper();
   bool _previewNavigationInProgress = false;
+  bool _studyInitializationStarted = false;
   String? _pendingPreviewRoute;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_studyInitializationStarted) return;
+    _studyInitializationStarted = true;
     initStudy();
   }
 


### PR DESCRIPTION
## Description
Fixes the app loading screen crash caused by reading `AppLocalizations` during `initState`. The loading screen now starts study initialization from `didChangeDependencies`, where inherited widgets such as `Localizations` are safe to access, and guards initialization so navigation/state setup still runs once.

## Visuals
<!-- REQUIRED: Attach a screenshot for static changes or a screen recording for interactive changes -->

## Testing Steps
- [x] Ran `fvm exec melos run qualitycheck`
- [x] Verified `app/lib/screens/app_onboarding/loading_screen.dart` analyzes without issues as part of qualitycheck

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
- [ ] Screenshot or video of the changes attached
- [ ] Description links related issues