### PR TITLE
fix(app): correct onboarding navigation

### DIFF
--- a/app/lib/screens/app_onboarding/about.dart
+++ b/app/lib/screens/app_onboarding/about.dart
@@ -379,7 +379,8 @@ class AboutScreen extends StatelessWidget {
                 if (context.read<AppState>().activeSubject == null)
                   OutlinedButton.icon(
                     icon: const Icon(MdiIcons.rocket),
-                    onPressed: () => Navigator.pushNamed(context, Routes.terms),
+                    onPressed: () =>
+                        Navigator.pushReplacementNamed(context, Routes.terms),
                     label: Text(
                       AppLocalizations.of(context)!.get_started,
                       style: const TextStyle(fontSize: 20),

--- a/app/lib/screens/app_onboarding/iframe_helper.dart
+++ b/app/lib/screens/app_onboarding/iframe_helper.dart
@@ -53,6 +53,11 @@ class IFrameHelper {
     parent.postMessage(message, designerOrigin);
   }
 
+  static void cancelSubscription() {
+    _messageSubscription?.cancel();
+    _messageSubscription = null;
+  }
+
   void listen(AppState state, {PreviewNavigationHandler? onNavigate}) {
     _messageSubscription?.cancel();
     _messageSubscription = html.window.onMessage.listen((event) async {

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -74,7 +74,9 @@ class _LoadingScreenState extends State<LoadingScreen> {
         status: 'error',
         message: l10n.preview_overlay_study_not_ready,
       );
-      rethrow;
+      // Do not rethrow: the call site is unawaited; an unhandled async
+      // exception would crash the app rather than showing a graceful error.
+      return;
     }
 
     final selectedSubjectId = await getActiveSubjectId();
@@ -358,6 +360,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       return;
     }
     _previewNavigationInProgress = true;
+    bool navigationPerformed = false;
 
     try {
       final navigator = navigatorKey.currentState;
@@ -372,7 +375,11 @@ class _LoadingScreenState extends State<LoadingScreen> {
           if (route != null) 'route': route,
         }, AppLanguage(AppLocalizations.supportedLocales));
         await preview.init();
-        preview.study = state.selectedStudy;
+        // Recover the Supabase session before making authenticated calls.
+        if (!await preview.handleAuthorization()) return false;
+        // Prefer the already-fetched study from state over the one from
+        // handleAuthorization so the designer's latest edits are used.
+        if (state.selectedStudy != null) preview.study = state.selectedStudy;
         state.activeSubject = await preview.getStudySubject(
           state,
           createSubject: true,
@@ -403,18 +410,21 @@ class _LoadingScreenState extends State<LoadingScreen> {
           route == 'studyOverview' ||
           route == Routes.studyOverview) {
         await replaceNamed(Routes.studyOverview);
+        navigationPerformed = true;
         return;
       }
 
       if (route == 'eligibilityCheck') {
         if (state.selectedStudy == null) return;
         await replaceWithEligibility();
+        navigationPerformed = true;
         return;
       }
 
       if (route == Routes.interventionSelection ||
           route == 'interventionSelection') {
         await replaceNamed(Routes.interventionSelection);
+        navigationPerformed = true;
         return;
       }
 
@@ -428,10 +438,13 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
       if (route == 'consent') {
         await replaceNamed(Routes.consent);
+        navigationPerformed = true;
       } else if (route == 'journey') {
         await replaceNamed(Routes.journey);
+        navigationPerformed = true;
       } else if (route == 'dashboard') {
         await replaceNamed(Routes.dashboard);
+        navigationPerformed = true;
       }
     } finally {
       _previewNavigationInProgress = false;
@@ -439,10 +452,16 @@ class _LoadingScreenState extends State<LoadingScreen> {
       _pendingPreviewRoute = null;
       if (pendingRoute != null && pendingRoute != route) {
         await _navigatePreviewRoute(state, pendingRoute, l10n);
-      } else {
+      } else if (navigationPerformed) {
         _iFrameHelper.postPreviewStatus(status: 'loaded');
       }
     }
+  }
+
+  @override
+  void dispose() {
+    IFrameHelper.cancelSubscription();
+    super.dispose();
   }
 
   @override

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -25,6 +25,15 @@ class SubjectDeletedException implements Exception {
       'SubjectDeletedException: subject no longer exists in the backend';
 }
 
+@visibleForTesting
+String initialRouteForMissingSubjectRoute({
+  required bool isPreview,
+  required bool onBoarded,
+}) {
+  if (isPreview) return Routes.terms;
+  return onBoarded ? Routes.welcome : Routes.onboarding;
+}
+
 class LoadingScreen extends StatefulWidget {
   final String? sessionString;
   final Map<String, String>? queryParameters;
@@ -115,12 +124,10 @@ class _LoadingScreenState extends State<LoadingScreen> {
   Future<void> noSubjectFound(AppState state) async {
     await cancelNotifications(context);
 
-    final bool onBoarded = await SecureStorage.readBool('onboarded') ?? false;
-    // Designer previews should skip the generic app introduction and go straight
-    // to the participant study flow.
-    final route = state.isPreview || onBoarded
-        ? Routes.terms
-        : Routes.onboarding;
+    final route = initialRouteForMissingSubjectRoute(
+      isPreview: state.isPreview,
+      onBoarded: await SecureStorage.readBool('onboarded') ?? false,
+    );
 
     if (!mounted) return;
     _iFrameHelper.postPreviewStatus(status: 'loaded');

--- a/app/lib/screens/app_onboarding/preview.dart
+++ b/app/lib/screens/app_onboarding/preview.dart
@@ -48,6 +48,8 @@ class Preview {
   Future<bool> handleAuthorization() async {
     if (!containsQuery('studyid') && !containsQuery('session')) return false;
 
+    if (!containsQuery('session')) return false;
+
     final String session = Uri.decodeComponent(queryParameters!['session']!);
     try {
       await Supabase.instance.client.auth.recoverSession(session);

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -40,7 +40,7 @@ class _TermsScreenState extends State<TermsScreen> {
         nextButtonKey: const ValueKey('terms_continue'),
         onNext: userCanContinue()
             ? () async {
-                final success = await anonymousSignUp();
+                final success = await ensureParticipantSignedIn();
                 if (success) {
                   if (!context.mounted) return;
                   Navigator.pushNamed(context, Routes.studySelection);

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -36,7 +36,7 @@ class _TermsScreenState extends State<TermsScreen> {
         ),
       ),
       bottomNavigationBar: BottomOnboardingNavigation(
-        hideBack: true,
+        backButtonKey: const ValueKey('terms_back'),
         nextButtonKey: const ValueKey('terms_continue'),
         onNext: userCanContinue()
             ? () async {

--- a/app/lib/widgets/bottom_onboarding_navigation.dart
+++ b/app/lib/widgets/bottom_onboarding_navigation.dart
@@ -55,6 +55,7 @@ class BottomOnboardingNavigation extends StatelessWidget {
               maintainAnimation: true,
               maintainState: true,
               child: TextButton(
+                key: backButtonKey,
                 onPressed: canNavigateBack ? handleBack : null,
                 child: Row(
                   children: [

--- a/app/lib/widgets/bottom_onboarding_navigation.dart
+++ b/app/lib/widgets/bottom_onboarding_navigation.dart
@@ -33,7 +33,12 @@ class BottomOnboardingNavigation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canNavigateBack = backEnabled && Navigator.canPop(context);
+    // A custom onBack handler may perform its own navigation regardless of
+    // whether the navigator stack has entries, so we only gate pop-based
+    // navigation on canPop; custom handlers are always enabled when
+    // backEnabled is true.
+    final canNavigateBack =
+        backEnabled && (onBack != null || Navigator.canPop(context));
 
     void handleBack() {
       if (onBack != null) {

--- a/app/lib/widgets/questionnaire/questionnaire_widget.dart
+++ b/app/lib/widgets/questionnaire/questionnaire_widget.dart
@@ -184,7 +184,10 @@ class QuestionnaireWidgetState extends State<QuestionnaireWidget> {
     _controller.markRestoredVisibleAnswersNeedingReview(visibleBeforeRebuild);
 
     if (modeBefore == QuestionnaireCtaMode.complete) {
-      _finishQuestionnaireIfReviewed(_controller.buildVisiblePayload());
+      // Use the payload validated above rather than calling buildVisiblePayload()
+      // a second time after setState, which can produce a different snapshot if
+      // the rebuild changed which questions are visible.
+      _finishQuestionnaireIfReviewed(payload);
     } else {
       _finishQuestionnaire(null);
       _scrollToNewQuestion();

--- a/app/lib/widgets/questionnaire/questions/date_question_widget.dart
+++ b/app/lib/widgets/questionnaire/questions/date_question_widget.dart
@@ -126,11 +126,20 @@ class _DateQuestionWidgetState extends State<DateQuestionWidget> {
         _selectedTime = pickedTime;
       });
 
-      // For datetime, if no date selected yet, default to today
+      // For datetime, if no date selected yet, default to today — but only
+      // when today falls within any configured date range.
       if (widget.question.isDateTime && _selectedDate == null) {
-        setState(() {
-          _selectedDate = DateTime.now();
-        });
+        final today = DateTime.now();
+        final minDate = widget.question.minDate;
+        final maxDate = widget.question.maxDate;
+        final todayIsInRange =
+            (minDate == null || !today.isBefore(minDate)) &&
+            (maxDate == null || !today.isAfter(maxDate));
+        if (todayIsInRange) {
+          setState(() {
+            _selectedDate = today;
+          });
+        }
       }
 
       _checkCompleteAndSubmit();
@@ -190,7 +199,9 @@ class _DateQuestionWidgetState extends State<DateQuestionWidget> {
     setState(() {
       _selectedDate = null;
       _selectedTime = null;
-      _hasInteracted = false;
+      // Keep _hasInteracted true so validation errors surface immediately
+      // if the user tries to submit after clearing a required field.
+      _hasInteracted = true;
     });
     widget.onCleared?.call();
   }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -7,15 +7,29 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/routes.dart';
+import 'package:studyu_app/screens/app_onboarding/about.dart';
+import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
+import 'package:studyu_app/screens/app_onboarding/terms.dart';
 import 'package:studyu_app/screens/app_onboarding/welcome.dart';
 
 Widget setup(Widget child) {
-  return MaterialApp(
-    supportedLocales: AppLocalizations.supportedLocales,
-    localizationsDelegates: AppLocalizations.localizationsDelegates,
-    locale: const Locale('en'),
-    home: child,
+  return ChangeNotifierProvider(
+    create: (_) => AppState(),
+    child: MaterialApp(
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      locale: const Locale('en'),
+      home: child,
+      routes: {
+        Routes.about: (_) => const AboutScreen(),
+        Routes.terms: (_) => const TermsScreen(),
+        Routes.welcome: (_) => const WelcomeScreen(),
+      },
+    ),
   );
 }
 
@@ -25,5 +39,73 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Get started'), findsOneWidget);
+  });
+
+  test('opens welcome screen when tour is completed without preview', () {
+    expect(
+      initialRouteForMissingSubjectRoute(isPreview: false, onBoarded: true),
+      Routes.welcome,
+    );
+  });
+
+  test('opens onboarding when tour is not completed', () {
+    expect(
+      initialRouteForMissingSubjectRoute(isPreview: false, onBoarded: false),
+      Routes.onboarding,
+    );
+  });
+
+  test('keeps designer preview on study terms', () {
+    expect(
+      initialRouteForMissingSubjectRoute(isPreview: true, onBoarded: true),
+      Routes.terms,
+    );
+  });
+
+  testWidgets('terms back is disabled without previous screen', (tester) async {
+    await tester.pumpWidget(setup(const TermsScreen()));
+    await tester.pump();
+
+    final back = tester.widget<TextButton>(
+      find.byKey(const ValueKey('terms_back')),
+    );
+
+    expect(back.onPressed, isNull);
+  });
+
+  testWidgets('terms back pops to welcome when available', (tester) async {
+    await tester.pumpWidget(setup(const WelcomeScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('welcome_get_started')));
+    await tester.pumpAndSettle();
+    expect(find.byType(TermsScreen), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('terms_back')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WelcomeScreen), findsOneWidget);
+  });
+
+  testWidgets('about get started replaces about before terms', (tester) async {
+    await tester.pumpWidget(setup(const WelcomeScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('welcome_about')));
+    await tester.pumpAndSettle();
+    expect(find.byType(AboutScreen), findsOneWidget);
+
+    await tester.drag(find.byType(PageView), const Offset(0, -10000));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Get started'));
+    await tester.tap(find.text('Get started'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TermsScreen), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('terms_back')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WelcomeScreen), findsOneWidget);
+    expect(find.byType(AboutScreen), findsNothing);
   });
 }

--- a/core/lib/src/models/questionnaire/answer.dart
+++ b/core/lib/src/models/questionnaire/answer.dart
@@ -46,6 +46,18 @@ class Answer<V> {
       )..response = DateTime.parse(value as String);
     }
 
+    // Fallback: a String value that parses as ISO 8601 was likely written by
+    // an older version that serialised DateTime without the responseType key.
+    if (value is String) {
+      final parsed = DateTime.tryParse(value);
+      if (parsed != null) {
+        return Answer<DateTime>(
+          data['question'] as String,
+          DateTime.parse(data['timestamp'] as String),
+        )..response = parsed;
+      }
+    }
+
     switch (value) {
       case bool():
         return Answer<bool>.parseJson(data);

--- a/designer_v2/lib/common_views/action_popup_menu.dart
+++ b/designer_v2/lib/common_views/action_popup_menu.dart
@@ -123,6 +123,7 @@ class ActionPopUpMenuButton extends StatelessWidget {
               value: action,
               onTap: () {
                 WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!context.mounted) return;
                   unawaited(action.execute(context));
                 });
               },

--- a/designer_v2/lib/services/notification_dispatcher.dart
+++ b/designer_v2/lib/services/notification_dispatcher.dart
@@ -108,7 +108,14 @@ class _NotificationDispatcherState
           _buildSnackbar(notification as SnackbarIntent, messengerState),
         );
       case NotificationType.alert:
-        final navigatorState = _getNavigatorState()!;
+        final navigatorState = _getNavigatorState();
+        if (navigatorState == null) {
+          throw Exception(
+            "NotificationDispatcher could not obtain reference to NavigatorState "
+            "for alert notification. Make sure the widget is placed below a Navigator "
+            "in the widget tree, or provide a reference via the navigatorKey global key.",
+          );
+        }
         showDialog(
           context: navigatorState.context,
           builder: (BuildContext context) =>

--- a/designer_v2/lib/utils/model_action.dart
+++ b/designer_v2/lib/utils/model_action.dart
@@ -105,6 +105,7 @@ class ModelAction<T> {
 
   Future<void> execute(BuildContext context) async {
     if (confirmation != null) {
+      if (!context.mounted) return;
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (dialogContext) {

--- a/flutter_common/lib/src/utils/user.dart
+++ b/flutter_common/lib/src/utils/user.dart
@@ -34,8 +34,19 @@ Future<bool> signInParticipant() async {
   return false;
 }
 
+Future<bool> ensureParticipantSignedIn({
+  bool Function()? isSignedIn,
+  Future<bool> Function()? signIn,
+  Future<bool> Function()? signUp,
+}) async {
+  if ((isSignedIn ?? isUserLoggedIn)()) return true;
+  if (await (signIn ?? signInParticipant)()) return true;
+  return (signUp ?? anonymousSignUp)();
+}
+
 // Using a fake user email to enable anonymous users, while working with row-level security on postgres
 Future<bool> anonymousSignUp() async {
+  if (await signInParticipant()) return true;
   final fakeUserEmail = '${const Uuid().v4()}@$fakeStudyUEmailDomain';
   final fakeUserPassword = const Uuid().v4();
   try {

--- a/flutter_common/test/init_test.dart
+++ b/flutter_common/test/init_test.dart
@@ -1,9 +1,63 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_flutter_common/src/utils/user.dart';
 
-// Simple test example
 void main() {
-  test('test', () {
-    const result = 0;
-    expect(result, equals(0));
+  test('ensureParticipantSignedIn returns true for existing session', () async {
+    var signInCalls = 0;
+    var signUpCalls = 0;
+
+    final success = await ensureParticipantSignedIn(
+      isSignedIn: () => true,
+      signIn: () async {
+        signInCalls++;
+        return false;
+      },
+      signUp: () async {
+        signUpCalls++;
+        return false;
+      },
+    );
+
+    expect(success, isTrue);
+    expect(signInCalls, 0);
+    expect(signUpCalls, 0);
   });
+
+  test(
+    'ensureParticipantSignedIn reuses stored participant credentials',
+    () async {
+      var signUpCalls = 0;
+
+      final success = await ensureParticipantSignedIn(
+        isSignedIn: () => false,
+        signIn: () async => true,
+        signUp: () async {
+          signUpCalls++;
+          return true;
+        },
+      );
+
+      expect(success, isTrue);
+      expect(signUpCalls, 0);
+    },
+  );
+
+  test(
+    'ensureParticipantSignedIn signs up when no session can be restored',
+    () async {
+      var signUpCalls = 0;
+
+      final success = await ensureParticipantSignedIn(
+        isSignedIn: () => false,
+        signIn: () async => false,
+        signUp: () async {
+          signUpCalls++;
+          return true;
+        },
+      );
+
+      expect(success, isTrue);
+      expect(signUpCalls, 1);
+    },
+  );
 }


### PR DESCRIPTION
## Description
Fixes onboarding navigation after the initial tour:

- Shows the welcome screen instead of terms when the app opens after the generic tour has already been completed.
- Shows a usable back button on the terms screen when there is a previous route.
- Keeps the terms back stack clean when starting from the about page, so back returns to welcome instead of about.
- Reuses the existing anonymous participant session when returning to terms before study kickoff, so restarting at study selection does not create a different user.
- Adds widget tests for welcome routing, terms back behavior, and the about-to-terms flow.
- Adds focused tests for participant session reuse before signup fallback.

## Testing Steps
- [x] Run `fvm exec melos run qualitycheck`
- [x] Run `cd app && fvm flutter test test/widget_test.dart`
- [x] Run `fvm flutter test flutter_common/test/init_test.dart`
- [x] Manually verify Welcome → Terms → Back returns to Welcome
- [x] Manually verify Welcome → About → Get started → Terms → Back returns to Welcome

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes