### PR TITLE
chore(app): add rtk filters

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,382 @@
+schema_version = 1
+
+[filters.fvm-melos-bootstrap]
+description = "Compact melos bootstrap success and failures"
+match_command = "^(fvm\\s+exec\\s+)?melos\\s+(bs|bootstrap)(\\s|$)"
+strip_ansi = true
+filter_stderr = true
+keep_lines_matching = [
+  "(?i)(error|exception|failed|failure|could not|not found|invalid|missing|denied|timed out|pub get failed|unable)",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+:\\d+",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+"
+]
+max_lines = 80
+on_empty = "melos bootstrap: ok"
+
+[filters.melos-qualitycheck]
+description = "Compact melos qualitycheck wrapper output"
+match_command = "^(fvm\\s+exec\\s+)?melos\\s+qualitycheck(\\s|$)"
+strip_ansi = true
+filter_stderr = true
+keep_lines_matching = [
+  "(?i)(error|exception|failed|failure|could not|not found|invalid|missing|denied|timed out|unable)",
+  "^\\s*(error|warning|info) - ",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+:\\d+",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+",
+  "^Formatted \\d+ files? \\([1-9]\\d* changed\\)",
+  "^dart analyze: No issues found$",
+  "^flutter analyze: No issues found$"
+]
+max_lines = 120
+on_empty = "qualitycheck: ok"
+
+[[tests.melos-qualitycheck]]
+name = "qualitycheck keeps compact success"
+input = """
+melos run qualitycheck
+  └> RUNNING
+studyu_app:
+Formatted 111 files (0 changed) in 0.47 seconds.
+studyu_app: SUCCESS
+dart analyze: No issues found
+flutter analyze: No issues found
+"""
+expected = "dart analyze: No issues found\nflutter analyze: No issues found"
+
+[[tests.melos-qualitycheck]]
+name = "qualitycheck keeps pubspec failure"
+input = """
+Resolving dependencies...
+Error on line 6, column 3 of pubspec.yaml: pubspec.yaml refers to an unknown sdk 'broken_yaml'.
+  ╷
+6 │   broken_yaml:
+  │   ^^^^^^^^^^^
+  ╵
+"""
+expected = "Error on line 6, column 3 of pubspec.yaml: pubspec.yaml refers to an unknown sdk 'broken_yaml'."
+
+[[tests.fvm-melos-bootstrap]]
+name = "bootstrap success is empty"
+input = """
+Running pub get...
+SUCCESS
+ -> 5 packages bootstrapped
+"""
+expected = "melos bootstrap: ok"
+
+[[tests.fvm-melos-bootstrap]]
+name = "bootstrap keeps option error"
+input = """
+Could not find an option named \"--definitely-bad-option\".
+Usage: melos bootstrap [arguments]
+"""
+expected = "Could not find an option named \"--definitely-bad-option\"."
+
+[[tests.fvm-melos-bootstrap]]
+name = "direct bootstrap keeps option error"
+input = """
+Could not find an option named \"--definitely-bad-option\".
+Usage: melos bootstrap [arguments]
+"""
+expected = "Could not find an option named \"--definitely-bad-option\"."
+
+[filters.fvm]
+description = "Compact FVM shell output only"
+match_command = "^fvm\\s+shell\\b"
+strip_ansi = true
+filter_stderr = true
+keep_lines_matching = [
+  "(?i)(error|exception|failed|failure|could not|not found|invalid|missing|denied|timed out|pub get failed|\\bwarning\\b)",
+  "^\\s*(error|warning|info) - ",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+:\\d+",
+  "^\\s*[A-Za-z0-9_./:-]+:\\d+"
+]
+max_lines = 120
+on_empty = "fvm: ok"
+
+[[tests.fvm]]
+name = "fvm shell success is empty"
+input = """
+fvm: Running version: \"3.44.4\"
+Flutter SDK: SDK Version : 3.44.4 is already installed.
+Project now uses Flutter SDK : SDK Version : 3.44.4
+"""
+expected = "fvm: ok"
+
+[[tests.fvm]]
+name = "fvm keeps failure"
+input = """
+Failed to install Flutter SDK.
+"""
+expected = "Failed to install Flutter SDK."
+
+[filters.dart-analyze]
+description = "Compact dart analyze — strip headers and info-level issues; keep error/warning lines and summary"
+match_command = "^dart\\s+analyze\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Analyzing ",
+  "^info -",
+  "^No issues found",
+]
+on_empty = "dart analyze: No issues found"
+max_lines = 80
+
+[[tests.dart-analyze]]
+name = "dart analyze success"
+input = """
+Analyzing studyu...
+No issues found!
+"""
+expected = "dart analyze: No issues found"
+
+[[tests.dart-analyze]]
+name = "dart analyze keeps warnings"
+input = """
+Analyzing lib...
+info - lib/a.dart:1:1 - info only - lint
+warning - lib/a.dart:2:1 - Unused import. - unused_import
+1 issue found.
+"""
+expected = "warning - lib/a.dart:2:1 - Unused import. - unused_import\n1 issue found."
+
+[filters.dart-pub-get]
+description = "Compact dart pub get — strip download noise; keep summary, warnings, and hints"
+match_command = "^dart\\s+pub\\s+(get|add|upgrade|downgrade|outdated)\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Resolving dependencies",
+  "^Downloading packages",
+  "^  [a-zA-Z_][a-zA-Z0-9_-]* \\d",
+]
+max_lines = 60
+
+[[tests.dart-pub-get]]
+name = "dart pub strips package list"
+input = """
+Resolving dependencies in `/repo`...
+Downloading packages...
+  analyzer 12.1.0 (14.0.0 available)
+Got dependencies in `/repo`!
+49 packages have newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.
+"""
+expected = "Got dependencies in `/repo`!\n49 packages have newer versions incompatible with dependency constraints.\nTry `dart pub outdated` for more information."
+
+[filters.dart-test]
+description = "Compact dart test output — strip loading and blank lines, keep all test results"
+match_command = "^dart\\s+test\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+\\s*:\\s*loading",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+\\s*:\\s*.*$",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+: All tests passed!",
+]
+on_empty = "ok dart test: all passed"
+max_lines = 80
+
+[[tests.dart-test]]
+name = "dart test success"
+input = """
+00:00 +0: loading test/example_test.dart
+00:00 +1: All tests passed!
+"""
+expected = "ok dart test: all passed"
+
+[[tests.dart-test]]
+name = "dart test keeps failure"
+input = """
+00:00 +0: loading test/example_test.dart
+00:00 +0 -1: test/example_test.dart: fails [E]
+  Expected: true
+    Actual: false
+00:00 +0 -1: Some tests failed.
+"""
+expected = "00:00 +0 -1: test/example_test.dart: fails [E]\n  Expected: true\n    Actual: false\n00:00 +0 -1: Some tests failed."
+
+[filters.flutter-analyze]
+description = "Compact flutter analyze — strip headers and info-level issues; keep error/warning lines and summary"
+match_command = "^flutter\\s+analyze\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Analyzing ",
+  "^info ",
+  "^No issues found",
+  "^Resolving dependencies",
+  "^Downloading packages",
+  "^Got dependencies",
+  "^  [a-zA-Z_][a-zA-Z0-9_-]* \\d",
+  "^\\d+ packages have newer",
+  "^Try `flutter pub outdated`",
+]
+on_empty = "flutter analyze: No issues found"
+max_lines = 80
+
+[[tests.flutter-analyze]]
+name = "flutter analyze success"
+input = """
+Analyzing studyu...
+No issues found! (ran in 3.5s)
+"""
+expected = "flutter analyze: No issues found"
+
+[[tests.flutter-analyze]]
+name = "flutter analyze keeps errors"
+input = """
+Analyzing broken.dart...
+info • info only • broken.dart:1:1 • lint
+error • Undefined method • broken.dart:24:5 • undefined_method
+1 issue found. (ran in 0.1s)
+"""
+expected = "error • Undefined method • broken.dart:24:5 • undefined_method\n1 issue found. (ran in 0.1s)"
+
+[filters.flutter-pub-get]
+description = "Compact flutter pub get — strip download noise; keep summary, warnings, and hints"
+match_command = "^flutter\\s+pub\\s+(get|add|upgrade|downgrade|outdated)\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Resolving dependencies",
+  "^Downloading packages",
+  "^  [a-zA-Z_][a-zA-Z0-9_-]* \\d",
+]
+max_lines = 60
+
+[[tests.flutter-pub-get]]
+name = "flutter pub strips package list"
+input = """
+Resolving dependencies in `/repo`...
+Downloading packages...
+  analyzer 12.1.0 (14.0.0 available)
+Got dependencies in `/repo`!
+49 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
+"""
+expected = "Got dependencies in `/repo`!\n49 packages have newer versions incompatible with dependency constraints.\nTry `flutter pub outdated` for more information."
+
+[filters.flutter-test]
+description = "Compact flutter test output — strip pub preamble, loading lines, and blank lines; keep test results only"
+match_command = "^flutter\\s+test\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+\\s*:\\s*loading",
+  "^Resolving dependencies",
+  "^Downloading packages",
+  "^Got dependencies",
+  "^  [a-zA-Z_][a-zA-Z0-9_-]* \\d",
+  "^\\d+ packages have newer",
+  "^Try `flutter pub outdated`",
+  "^The following plugins do not support",
+  "^  - ",
+  "^This will become an error",
+  "^Running",
+  "^\\[\\+\\d+ ms\\] ",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+\\s*:\\s*.*$",
+  "^\\d\\d:\\d\\d\\s+\\+\\d+: All tests passed!",
+]
+on_empty = "ok flutter test: all passed"
+max_lines = 80
+
+[[tests.flutter-test]]
+name = "flutter test success"
+input = """
+Resolving dependencies...
+Got dependencies!
+00:00 +0: loading test/widget_test.dart
+00:00 +1: All tests passed!
+"""
+expected = "ok flutter test: all passed"
+
+[[tests.flutter-test]]
+name = "flutter test keeps failure"
+input = """
+Resolving dependencies...
+Downloading packages...
+  analyzer 12.1.0 (14.0.0 available)
+Got dependencies!
+00:00 +0: loading test/widget_test.dart
+00:00 +0 -1: test/widget_test.dart: fails [E]
+  Expected: true
+    Actual: false
+00:00 +0 -1: Some tests failed.
+"""
+expected = "00:00 +0 -1: test/widget_test.dart: fails [E]\n  Expected: true\n    Actual: false\n00:00 +0 -1: Some tests failed."
+
+[filters.dart-build-runner]
+description = "Compact dart run build_runner — strip AOT compile progress, per-file intermediate lines; keep builder summaries, warnings, and final result"
+match_command = "^dart\\s+run\\s+build_runner\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*\\d+s compiling builders",
+  "^W These options have been removed",
+  ".*;\\s*\\S+\\.dart$",
+]
+max_lines = 60
+
+[[tests.dart-build-runner]]
+name = "build runner keeps summaries"
+input = """
+  1s compiling builders/aot
+  0s json_serializable on 95 inputs; lib/core.dart
+  0s json_serializable on 95 inputs: 95 skipped
+  Built with build_runner/aot in 0s; wrote 0 outputs.
+"""
+expected = "  0s json_serializable on 95 inputs: 95 skipped\n  Built with build_runner/aot in 0s; wrote 0 outputs."
+
+[filters.flutter-build]
+description = "Compact flutter build — strip pub preamble, plugin warnings, tree-shaking, spinners; keep errors, wasm findings, build result"
+match_command = "^flutter\\s+build\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Resolving dependencies",
+  "^Downloading packages",
+  "^  [a-zA-Z_][a-zA-Z0-9_-]* \\d",
+  "^Got dependencies",
+  "^\\d+ packages have newer",
+  "^Try `flutter pub outdated`",
+  "^The following plugins do not support",
+  "^  - ",
+  "^This will become an error",
+  "^Font asset",
+  "^Compiling ",
+  "^Running",
+  "^\\[\\+\\d+ ms\\] ",
+]
+max_lines = 60
+
+[[tests.flutter-build]]
+name = "flutter build keeps result"
+input = """
+Resolving dependencies...
+Downloading packages...
+  analyzer 12.1.0 (14.0.0 available)
+Got dependencies!
+Font asset x was tree-shaken.
+✓ Built build/web
+"""
+expected = "✓ Built build/web"
+
+[[tests.flutter-build]]
+name = "flutter build keeps error"
+input = """
+Resolving dependencies...
+lib/main.dart:10:5: Error: bad
+    foo();
+    ^^^
+"""
+expected = "lib/main.dart:10:5: Error: bad\n    foo();\n    ^^^"

--- a/app/.rtk/filters.toml
+++ b/app/.rtk/filters.toml
@@ -1,0 +1,1 @@
+../../.rtk/filters.toml

--- a/core/.rtk/filters.toml
+++ b/core/.rtk/filters.toml
@@ -1,0 +1,1 @@
+../../.rtk/filters.toml

--- a/designer_v2/.rtk/filters.toml
+++ b/designer_v2/.rtk/filters.toml
@@ -1,0 +1,1 @@
+../../.rtk/filters.toml

--- a/flutter_common/.rtk/filters.toml
+++ b/flutter_common/.rtk/filters.toml
@@ -1,0 +1,1 @@
+../../.rtk/filters.toml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,16 +44,24 @@ melos:
 
     test:
       run: |
+        rtk_prefix=""
+        if command -v rtk >/dev/null 2>&1; then
+          rtk_prefix="rtk "
+        fi
         melos exec -c 6 --fail-fast -- \
-          "flutter test"
+          "${rtk_prefix}flutter test"
       description: Run `flutter test` for a specific package.
       packageFilters:
         dirExists: test
 
     generate:
       run: |
+        rtk_prefix=""
+        if command -v rtk >/dev/null 2>&1; then
+          rtk_prefix="rtk "
+        fi
         melos exec -c 1 --fail-fast -- \
-          "dart run build_runner build"
+          "${rtk_prefix}dart run build_runner build"
       description: Generate files with build_runner
       packageFilters:
         scope:
@@ -62,17 +70,21 @@ melos:
 
     qualitycheck:
       run: |
+        rtk_prefix=""
+        if command -v rtk >/dev/null 2>&1; then
+          rtk_prefix="rtk "
+        fi
         if [ "$CI" != "true" ]; then
           fvm install
         fi
         melos format
         melos generate
         if [ "$CI" = "true" ]; then
-          dart analyze
-          flutter analyze
+          ${rtk_prefix}dart analyze
+          ${rtk_prefix}flutter analyze
         else
-          fvm dart analyze
-          fvm flutter analyze
+          fvm exec ${rtk_prefix}dart analyze
+          fvm exec ${rtk_prefix}flutter analyze
         fi
       description: Run format, generate, and analyze checks
 

--- a/tools/studyu_mcp/.rtk/filters.toml
+++ b/tools/studyu_mcp/.rtk/filters.toml
@@ -1,0 +1,1 @@
+../../../.rtk/filters.toml


### PR DESCRIPTION
## Description
Adds project-local RTK filters for Dart, Flutter, Melos bootstrap, and Melos qualitycheck output. Updates Melos scripts so Dart and Flutter child commands use RTK when available, while falling back to normal commands when RTK is not installed.

## Testing Steps
- [x] `rtk trust` reports no high-risk patterns for `.rtk/filters.toml`
- [x] `rtk verify` passes with `174/174 tests passed`
- [x] `fvm exec melos run qualitycheck` passes
- [x] `rtk melos qualitycheck` returns compact analyzer output
- [x] check `rtk melos bs`
- [x] `RTK_TOML_DEBUG=1 rtk dart run build_runner build --help` from `core/` matches `dart-build-runner`

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
