### PR TITLE
chore(designer): add ide run configs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,12 @@
 <!-- Explain the change, motivation, and link related issues (e.g., Fixes #123) -->
 
 ## Visuals
-<!-- REQUIRED: Attach a screenshot for static changes or a screen recording for interactive changes -->
+<!-- Attach a screenshot for static UI changes or a screen recording for interactive UI changes. Remove this section when the PR has no visual impact. -->
 
 ## Testing Steps
 <!-- Provide step-by-step instructions so reviewers can verify this change locally -->
 
 ### PR Checklist
 - [ ] `fvm exec melos run qualitycheck` passes
-- [ ] Screenshot or video of the changes attached
-- [ ] Description links related issues
+- [ ] Screenshot or video attached, or this item removed for non-visual changes
+- [ ] Description links related issues, or this item removed when no issue exists

--- a/.run/app_dev.run.xml
+++ b/.run/app_dev.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="App - Dev" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--dart-define=STUDYU_ENV=.env.dev --web-port 8080" />
+    <option name="filePath" value="$PROJECT_DIR$/app/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/app_local.run.xml
+++ b/.run/app_local.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="App - Local" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--dart-define=STUDYU_ENV=.env.local --web-port 8080" />
+    <option name="filePath" value="$PROJECT_DIR$/app/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/app_remote.run.xml
+++ b/.run/app_remote.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="App - Remote" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--web-port 8080" />
+    <option name="filePath" value="$PROJECT_DIR$/app/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/designer_dev.run.xml
+++ b/.run/designer_dev.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Designer - Dev" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--dart-define=STUDYU_ENV=.env.dev --web-port 8081" />
+    <option name="filePath" value="$PROJECT_DIR$/designer_v2/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/designer_local.run.xml
+++ b/.run/designer_local.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Designer - Local" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--dart-define=STUDYU_ENV=.env.local --web-port 8081 --dart-define=EMAIL=user1@studyu.health --dart-define=PASSWORD=user1pass --dart-define=AUTO_LOGIN=true" />
+    <option name="filePath" value="$PROJECT_DIR$/designer_v2/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/designer_remote.run.xml
+++ b/.run/designer_remote.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Designer - Remote" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--web-port 8081" />
+    <option name="filePath" value="$PROJECT_DIR$/designer_v2/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ You must strictly adhere to the following workspace rules for all file modificat
 
 Before staging changes, committing, or opening a Pull Request, you MUST run `fvm exec melos run qualitycheck`.
 
+If `fvm exec melos run qualitycheck` prints `[rtk] WARNING: untrusted project filters (.rtk/filters.toml)`, review `.rtk/filters.toml`. If it only contains repository-owned output filters, run `rtk trust`, then rerun `fvm exec melos run qualitycheck`.
+
 ### 2. Commit Message Enforcement
 
 You must use the Conventional Commits format for all commits. Never generate a generic commit message.


### PR DESCRIPTION
## Description
Adds shared JetBrains Flutter run configurations for the participant app and Designer v2. The configs cover dev, local, and remote launches with consistent web ports. The Designer local config includes the existing local Supabase seed credentials and auto-login dart defines so local development starts from the seeded user documented in `supabase/README.md`.

Also updates the PR template guidance so agents can remove visual and issue-link checklist items when they do not apply, and documents the `rtk trust` workflow for reviewed repository filters.

## Testing Steps
- [x] `rtk trust` reviewed and trusted `.rtk/filters.toml`
- [x] `fvm exec melos run qualitycheck` passes
- [x] In JetBrains, open the run configuration list and verify App/Designer dev, local, and remote configs appear
- [x] Launch `Designer - Local` and verify it targets `.env.local`, port 8081, and auto-fills/signs in with the seeded local user

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
