### PR TITLE
STUDYU-60 fix(app): block unavailable studies from participant flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,4 +176,8 @@ interview/
 
 # Local git worktrees
 .worktrees/
+
+# Local subagent artifacts
+.pi-subagents/
+
 .vscode/settings.json

--- a/app/lib/app_router.dart
+++ b/app/lib/app_router.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/about.dart';
 import 'package:studyu_app/screens/app_onboarding/app_error_screen.dart';
 import 'package:studyu_app/screens/app_onboarding/app_outdated_screen.dart';
 import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
 import 'package:studyu_app/screens/app_onboarding/onboarding_screen.dart';
+import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
 import 'package:studyu_app/screens/app_onboarding/terms.dart';
 import 'package:studyu_app/screens/app_onboarding/welcome.dart';
 import 'package:studyu_app/screens/study/dashboard/contact_tab/contact_screen.dart';
@@ -32,6 +35,7 @@ class RouteNames {
   static const String preview = 'preview';
   static const String appOutdated = 'appOutdated';
   static const String appErrorScreen = 'appError';
+  static const String studyUnavailable = 'studyUnavailable';
   static const String dashboard = 'dashboard';
   static const String welcome = 'welcome';
   static const String onboarding = 'onboarding';
@@ -56,6 +60,9 @@ class RouteNames {
   static const String invite = 'invite';
   static const String study = 'study';
 }
+
+bool isStudyAvailableForTesting(Study study) =>
+    study.interventions.length >= StudySchedule.numberOfInterventions;
 
 /// Creates and configures the GoRouter instance for the app
 GoRouter createAppRouter({
@@ -86,6 +93,23 @@ GoRouter createAppRouter({
           }
         }
       }
+
+      final appState = context.read<AppState>();
+      final study = switch (state.uri.path) {
+        '/${RouteNames.studyOverview}' ||
+        '/${RouteNames.interventionSelection}' ||
+        '/${RouteNames.eligibilityCheck}' => appState.selectedStudy,
+        '/${RouteNames.journey}' ||
+        '/${RouteNames.consent}' ||
+        '/${RouteNames.kickoff}' ||
+        '/${RouteNames.dashboard}' =>
+          appState.activeSubject?.study ?? appState.selectedStudy,
+        _ => null,
+      };
+      if (study != null && !isStudyAvailableForTesting(study)) {
+        return '/${RouteNames.studyUnavailable}';
+      }
+
       // Remove splash screen when navigating away from loading screen
       if (state.uri.path != '/${RouteNames.loading}') {
         FlutterNativeSplash.remove();
@@ -125,6 +149,11 @@ GoRouter createAppRouter({
             reason: arguments.reason,
           );
         },
+      ),
+      GoRoute(
+        path: '/${RouteNames.studyUnavailable}',
+        name: RouteNames.studyUnavailable,
+        builder: (context, state) => const StudyUnavailableScreen(),
       ),
       GoRoute(
         path: '/${RouteNames.dashboard}',

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -87,6 +87,7 @@
   "setting_up_study": "Studie wird vorbereitet...",
   "good_to_go": "Es kann losgehen!",
   "dashboard": "Dashboard",
+  "study_not_available_for_testing_yet": "Diese Studie ist noch nicht zum Testen verfügbar.",
   "home": "Home",
   "profile": "Profil",
   "help": "Hilfe",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -86,6 +86,7 @@
   "setting_up_study": "Setting up your study...",
   "good_to_go": "You are good to go!",
   "dashboard": "Dashboard",
+  "study_not_available_for_testing_yet": "This study is not available for testing yet.",
   "home": "Home",
   "profile": "Profile",
   "help": "Help",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -614,6 +614,12 @@ abstract class AppLocalizations {
   /// **'Dashboard'**
   String get dashboard;
 
+  /// No description provided for @study_not_available_for_testing_yet.
+  ///
+  /// In en, this message translates to:
+  /// **'This study is not available for testing yet.'**
+  String get study_not_available_for_testing_yet;
+
   /// No description provided for @home.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -302,6 +302,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dashboard => 'Dashboard';
 
   @override
+  String get study_not_available_for_testing_yet =>
+      'Diese Studie ist noch nicht zum Testen verfügbar.';
+
+  @override
   String get home => 'Home';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -300,6 +300,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dashboard => 'Dashboard';
 
   @override
+  String get study_not_available_for_testing_yet =>
+      'This study is not available for testing yet.';
+
+  @override
   String get home => 'Home';
 
   @override

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -369,6 +369,10 @@ class _LoadingScreenState extends State<LoadingScreen> {
     if (subject != null) {
       subject = await Cache.synchronize(subject);
       if (!mounted) return;
+      if (!isStudyAvailableForTesting(subject.study)) {
+        context.go('/${RouteNames.studyUnavailable}');
+        return;
+      }
       state.activeSubject = subject;
       state.init(context);
       context.go('/${RouteNames.dashboard}');

--- a/app/lib/screens/app_onboarding/study_unavailable_screen.dart
+++ b/app/lib/screens/app_onboarding/study_unavailable_screen.dart
@@ -9,6 +9,7 @@ class StudyUnavailableScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final router = GoRouter.maybeOf(context);
 
     return Scaffold(
       body: SafeArea(
@@ -28,18 +29,20 @@ class StudyUnavailableScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 20),
                 ),
-                const SizedBox(height: 24),
-                OutlinedButton.icon(
-                  icon: const Icon(Icons.arrow_back),
-                  label: Text(l10n.back),
-                  onPressed: () {
-                    if (context.canPop()) {
-                      context.pop();
-                    } else {
-                      context.goNamed(RouteNames.welcome);
-                    }
-                  },
-                ),
+                if (router != null) ...[
+                  const SizedBox(height: 24),
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.arrow_back),
+                    label: Text(l10n.back),
+                    onPressed: () {
+                      if (router.canPop()) {
+                        router.pop();
+                      } else {
+                        router.goNamed(RouteNames.welcome);
+                      }
+                    },
+                  ),
+                ],
               ],
             ),
           ),

--- a/app/lib/screens/app_onboarding/study_unavailable_screen.dart
+++ b/app/lib/screens/app_onboarding/study_unavailable_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 
 class StudyUnavailableScreen extends StatelessWidget {
@@ -28,18 +27,14 @@ class StudyUnavailableScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 20),
                 ),
-                const SizedBox(height: 24),
-                OutlinedButton.icon(
-                  icon: const Icon(Icons.arrow_back),
-                  label: Text(l10n.back),
-                  onPressed: () {
-                    if (context.canPop()) {
-                      context.pop();
-                    } else {
-                      context.goNamed(RouteNames.welcome);
-                    }
-                  },
-                ),
+                if (context.canPop()) ...[
+                  const SizedBox(height: 24),
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.arrow_back),
+                    label: Text(l10n.back),
+                    onPressed: context.pop,
+                  ),
+                ],
               ],
             ),
           ),

--- a/app/lib/screens/app_onboarding/study_unavailable_screen.dart
+++ b/app/lib/screens/app_onboarding/study_unavailable_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:studyu_app/app_router.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+
+class StudyUnavailableScreen extends StatelessWidget {
+  const StudyUnavailableScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Image(
+                  image: AssetImage('assets/icon/logo.png'),
+                  height: 200,
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  l10n.study_not_available_for_testing_yet,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 20),
+                ),
+                const SizedBox(height: 24),
+                OutlinedButton.icon(
+                  icon: const Icon(Icons.arrow_back),
+                  label: Text(l10n.back),
+                  onPressed: () {
+                    if (context.canPop()) {
+                      context.pop();
+                    } else {
+                      context.goNamed(RouteNames.welcome);
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/app_onboarding/study_unavailable_screen.dart
+++ b/app/lib/screens/app_onboarding/study_unavailable_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 
 class StudyUnavailableScreen extends StatelessWidget {
@@ -27,14 +28,18 @@ class StudyUnavailableScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(fontSize: 20),
                 ),
-                if (context.canPop()) ...[
-                  const SizedBox(height: 24),
-                  OutlinedButton.icon(
-                    icon: const Icon(Icons.arrow_back),
-                    label: Text(l10n.back),
-                    onPressed: context.pop,
-                  ),
-                ],
+                const SizedBox(height: 24),
+                OutlinedButton.icon(
+                  icon: const Icon(Icons.arrow_back),
+                  label: Text(l10n.back),
+                  onPressed: () {
+                    if (context.canPop()) {
+                      context.pop();
+                    } else {
+                      context.goNamed(RouteNames.welcome);
+                    }
+                  },
+                ),
               ],
             ),
           ),

--- a/app/lib/screens/app_onboarding/terms.dart
+++ b/app/lib/screens/app_onboarding/terms.dart
@@ -46,10 +46,10 @@ class _TermsScreenState extends State<TermsScreen> {
         :final preselectedInterventionIds,
         :final alreadyEnrolled,
       ):
+        state.selectedStudy = study;
         if (alreadyEnrolled) {
           context.go('/${RouteNames.dashboard}');
         } else {
-          state.selectedStudy = study;
           if (inviteCode != null) {
             state.inviteCode = inviteCode;
             state.preselectedInterventionIds = preselectedInterventionIds;

--- a/app/lib/screens/study/dashboard/dashboard.dart
+++ b/app/lib/screens/study/dashboard/dashboard.dart
@@ -13,6 +13,7 @@ import 'package:showcaseview/showcaseview.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
 import 'package:studyu_app/screens/study/dashboard/task_overview_tab/task_overview.dart';
 import 'package:studyu_app/theme.dart' as app_theme;
 import 'package:studyu_app/util/dashboard_showcase.dart';
@@ -55,6 +56,8 @@ class _DashboardScreenState extends State<DashboardScreen>
   bool _redirectingToLoading = false;
   bool _isDisposing = false;
 
+  bool get _studyIsAvailable => isStudyAvailableForTesting(subject!.study);
+
   bool get showNextDay =>
       (kDebugMode || context.read<AppState>().isPreview) &&
       !subject!.completedStudy;
@@ -92,9 +95,11 @@ class _DashboardScreenState extends State<DashboardScreen>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        setState(() {
-          scheduleToday = subject!.scheduleFor(DateTime.now());
-        });
+        if (subject != null && _studyIsAvailable) {
+          setState(() {
+            scheduleToday = subject!.scheduleFor(DateTime.now());
+          });
+        }
       case AppLifecycleState.inactive:
         break;
       case AppLifecycleState.paused:
@@ -110,7 +115,7 @@ class _DashboardScreenState extends State<DashboardScreen>
   void didChangeDependencies() {
     super.didChangeDependencies();
     subject = context.watch<AppState>().activeSubject;
-    if (subject != null) {
+    if (subject != null && _studyIsAvailable) {
       scheduleToday = subject!.scheduleFor(DateTime.now());
       if (widget.error != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -142,6 +147,10 @@ class _DashboardScreenState extends State<DashboardScreen>
         });
       }
       return const SizedBox.shrink();
+    }
+
+    if (!_studyIsAvailable) {
+      return const StudyUnavailableScreen();
     }
 
     final isPreviewMode = context.read<AppState>().isPreview;

--- a/app/test/app_router_test.dart
+++ b/app/test/app_router_test.dart
@@ -5,7 +5,6 @@ import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
-import 'package:studyu_app/screens/app_onboarding/welcome.dart';
 import 'package:studyu_app/screens/study/onboarding/journey_overview.dart';
 import 'package:studyu_app/screens/study/onboarding/study_overview.dart';
 import 'package:studyu_core/core.dart';
@@ -53,17 +52,13 @@ void main() {
       '/${RouteNames.studyUnavailable}',
     );
 
-    await tester.tap(find.text('Back'));
-    await tester.pumpAndSettle();
-    expect(find.byType(WelcomeScreen), findsOneWidget);
+    expect(find.text('Back'), findsNothing);
 
     router.push('/${RouteNames.studyOverview}');
     await tester.pumpAndSettle();
     expect(find.byType(StudyUnavailableScreen), findsOneWidget);
     expect(find.byType(StudyOverviewScreen), findsNothing);
 
-    await tester.tap(find.text('Back'));
-    await tester.pumpAndSettle();
     appState
       ..selectedStudy = null
       ..activeSubject = StudySubject.fromStudy(study, 'user', [], null);

--- a/app/test/app_router_test.dart
+++ b/app/test/app_router_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_app/app_router.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
+import 'package:studyu_app/screens/app_onboarding/welcome.dart';
+import 'package:studyu_app/screens/study/onboarding/journey_overview.dart';
+import 'package:studyu_app/screens/study/onboarding/study_overview.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_core/env.dart';
+import 'package:supabase/supabase.dart';
+
+void main() {
+  testWidgets('invalid study routes stay on unavailable screen', (
+    tester,
+  ) async {
+    final supabase = SupabaseClient(
+      'http://localhost',
+      'anon',
+      authOptions: const AuthClientOptions(autoRefreshToken: false),
+    );
+    setEnv(
+      'http://localhost',
+      'anon',
+      supabaseClient: supabase,
+      envAppDeepLinkScheme: 'studyu-app://',
+    );
+    final study = Study('study', 'user')
+      ..interventions = [Intervention('intervention', 'Intervention')];
+    final appState = AppState()..selectedStudy = study;
+    final router = createAppRouter(
+      queryParameters: const {},
+      initialLocation: '/${RouteNames.studyUnavailable}',
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: appState,
+        child: MaterialApp.router(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/${RouteNames.studyUnavailable}',
+    );
+
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+    expect(find.byType(WelcomeScreen), findsOneWidget);
+
+    router.push('/${RouteNames.studyOverview}');
+    await tester.pumpAndSettle();
+    expect(find.byType(StudyUnavailableScreen), findsOneWidget);
+    expect(find.byType(StudyOverviewScreen), findsNothing);
+
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+    appState
+      ..selectedStudy = null
+      ..activeSubject = StudySubject.fromStudy(study, 'user', [], null);
+
+    router.push('/${RouteNames.journey}');
+    await tester.pumpAndSettle();
+    expect(find.byType(StudyUnavailableScreen), findsOneWidget);
+    expect(find.byType(JourneyOverviewScreen), findsNothing);
+  });
+}

--- a/app/test/app_router_test.dart
+++ b/app/test/app_router_test.dart
@@ -5,6 +5,7 @@ import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
+import 'package:studyu_app/screens/app_onboarding/welcome.dart';
 import 'package:studyu_app/screens/study/onboarding/journey_overview.dart';
 import 'package:studyu_app/screens/study/onboarding/study_overview.dart';
 import 'package:studyu_core/core.dart';
@@ -52,13 +53,17 @@ void main() {
       '/${RouteNames.studyUnavailable}',
     );
 
-    expect(find.text('Back'), findsNothing);
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+    expect(find.byType(WelcomeScreen), findsOneWidget);
 
     router.push('/${RouteNames.studyOverview}');
     await tester.pumpAndSettle();
     expect(find.byType(StudyUnavailableScreen), findsOneWidget);
     expect(find.byType(StudyOverviewScreen), findsNothing);
 
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
     appState
       ..selectedStudy = null
       ..activeSubject = StudySubject.fromStudy(study, 'user', [], null);

--- a/app/test/screens/study/dashboard/dashboard_test.dart
+++ b/app/test/screens/study/dashboard/dashboard_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/screens/study/dashboard/dashboard.dart';
+import 'package:studyu_app/screens/study/dashboard/task_overview_tab/task_overview.dart';
+import 'package:studyu_core/core.dart';
+
+Widget _dashboardWith(int interventionCount, {bool withTask = false}) {
+  final study = Study('study', 'user')
+    ..status = StudyStatus.running
+    ..interventions = List.generate(
+      interventionCount,
+      (index) => Intervention('intervention-$index', 'Intervention $index'),
+    );
+  if (withTask) {
+    study.interventions.single.tasks = [
+      CheckmarkTask.withId()..title = 'Ignored task',
+    ];
+  }
+
+  final subject = StudySubject.fromStudy(
+    study,
+    'user',
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.now().add(const Duration(days: 1));
+  final appState = AppState()..activeSubject = subject;
+  appState.updatePreviewMode(true);
+
+  return ChangeNotifierProvider.value(
+    value: appState,
+    child: const MaterialApp(
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      locale: Locale('en'),
+      home: DashboardScreen(),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('study with one intervention stays unavailable despite tasks', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_dashboardWith(1, withTask: true));
+
+    expect(
+      find.text('This study is not available for testing yet.'),
+      findsOneWidget,
+    );
+    expect(find.byType(AppBar), findsNothing);
+    expect(find.byType(TaskOverview), findsNothing);
+    expect(find.text('Dashboard'), findsNothing);
+  });
+
+  testWidgets('study with two interventions shows dashboard', (tester) async {
+    await tester.pumpWidget(_dashboardWith(2));
+
+    expect(
+      find.text('This study is not available for testing yet.'),
+      findsNothing,
+    );
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.text('Dashboard'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description

Studies with fewer than two defined interventions could enter participant onboarding and crash while building the journey timeline. The participant app now routes those studies to a dedicated unavailable screen before loading study-specific UI.

- Determine availability from the study-defined intervention count only; tasks do not affect the result.
- Guard overview, intervention selection, eligibility, journey, consent, kickoff, and dashboard routes.
- Stop restored invalid studies before dashboard initialization and prevent dashboard lifecycle work when an invalid subject is mounted.
- Add a Back action that pops when possible and otherwise returns to Welcome.
- Add English and German copy plus focused router and dashboard widget tests.
- Ignore local `.pi-subagents/` artifacts.

## Visuals

<img width="362" height="776" alt="Screenshot 2026-07-13 at 13 14 38" src="https://github.com/user-attachments/assets/fd0bb793-7d57-467e-987a-51d7629e061f" />

## Testing Steps

1. Enter an invite code for a study with zero or one intervention.
2. Confirm the app shows the unavailable-study screen without rendering the overview or journey.
3. Tap Back and confirm it returns to the previous screen, or Welcome when no route history exists.
4. Open a study with exactly two interventions and confirm the normal dashboard remains available.
5. Run `cd app && rtk fvm flutter test test/app_router_test.dart`.
6. Run `cd app && rtk fvm flutter test test/screens/study/dashboard/dashboard_test.dart`.
7. Run `scripts/pre-commit-check`.

### PR Checklist
- [x] `scripts/pre-commit-check` passes
