### PR TITLE
fix(designer): align destructive discard confirmation

### DIFF
--- a/designer_v2/lib/common_views/confirmation_dialog.dart
+++ b/designer_v2/lib/common_views/confirmation_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:studyu_designer_v2/common_views/dialog.dart';
 import 'package:studyu_designer_v2/common_views/primary_button.dart';
 import 'package:studyu_designer_v2/common_views/secondary_button.dart';
@@ -39,65 +40,67 @@ class StandardConfirmationDialog extends StatelessWidget {
     final theme = Theme.of(context);
     final severityColor = theme.colorScheme.error;
 
-    return StandardDialog(
-      title: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (icon != null) ...[
-            Icon(icon, color: isDestructive ? severityColor : null),
-            const SizedBox(width: 8),
-          ],
-          Flexible(
-            child: SelectableText(
-              title,
-              style: theme.textTheme.displaySmall?.copyWith(
-                fontWeight: FontWeight.normal,
-                color: theme.colorScheme.onPrimaryContainer,
+    return PointerInterceptor(
+      child: StandardDialog(
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, color: isDestructive ? severityColor : null),
+              const SizedBox(width: 8),
+            ],
+            Flexible(
+              child: SelectableText(
+                title,
+                style: theme.textTheme.displaySmall?.copyWith(
+                  fontWeight: FontWeight.normal,
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
               ),
             ),
-          ),
+          ],
+        ),
+        body:
+            customContent ??
+            (message == null
+                ? const SizedBox.shrink()
+                : TextParagraph(text: message)),
+        actionButtons: [
+          for (final (index, action) in actions.indexed)
+            if (action.isDestructive)
+              PrimaryButton(
+                onPressed: action.onPressed,
+                text: action.label,
+                icon: null,
+                backgroundColor: severityColor,
+                foregroundColor: Colors.white,
+                minimumSize: const Size(120, 40),
+              )
+            else if (isDestructive)
+              SecondaryButton(
+                onPressed: action.onPressed,
+                text: action.label,
+                icon: null,
+                minimumSize: const Size(120, 40),
+              )
+            else if (index == 0)
+              PrimaryButton(
+                onPressed: action.onPressed,
+                text: action.label,
+                icon: null,
+                minimumSize: const Size(120, 40),
+              )
+            else
+              SecondaryButton(
+                onPressed: action.onPressed,
+                text: action.label,
+                icon: null,
+                minimumSize: const Size(120, 40),
+              ),
         ],
+        maxWidth: 500,
+        minHeight: 0,
       ),
-      body:
-          customContent ??
-          (message == null
-              ? const SizedBox.shrink()
-              : TextParagraph(text: message)),
-      actionButtons: [
-        for (final (index, action) in actions.indexed)
-          if (action.isDestructive)
-            PrimaryButton(
-              onPressed: action.onPressed,
-              text: action.label,
-              icon: null,
-              backgroundColor: severityColor,
-              foregroundColor: Colors.white,
-              minimumSize: const Size(120, 40),
-            )
-          else if (isDestructive)
-            SecondaryButton(
-              onPressed: action.onPressed,
-              text: action.label,
-              icon: null,
-              minimumSize: const Size(120, 40),
-            )
-          else if (index == 0)
-            PrimaryButton(
-              onPressed: action.onPressed,
-              text: action.label,
-              icon: null,
-              minimumSize: const Size(120, 40),
-            )
-          else
-            SecondaryButton(
-              onPressed: action.onPressed,
-              text: action.label,
-              icon: null,
-              minimumSize: const Size(120, 40),
-            ),
-      ],
-      maxWidth: 500,
-      minHeight: 0,
     );
   }
 }

--- a/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
+++ b/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:studyu_designer_v2/common_views/confirmation_dialog.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
@@ -7,20 +8,22 @@ class UnsavedChangesDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StandardConfirmationDialog(
-      title: tr.dialog_unsaved_changes_title,
-      message: tr.dialog_unsaved_changes_description,
-      actions: [
-        ConfirmationDialogAction(
-          label: tr.dialog_action_unsaved_changes_stay,
-          onPressed: () => Navigator.pop(context, false),
-        ),
-        ConfirmationDialogAction(
-          label: tr.dialog_action_unsaved_changes_discard,
-          isDestructive: true,
-          onPressed: () => Navigator.pop(context, true),
-        ),
-      ],
+    return PointerInterceptor(
+      child: StandardConfirmationDialog(
+        title: tr.dialog_unsaved_changes_title,
+        message: tr.dialog_unsaved_changes_description,
+        actions: [
+          ConfirmationDialogAction(
+            label: tr.dialog_action_unsaved_changes_stay,
+            onPressed: () => Navigator.pop(context, false),
+          ),
+          ConfirmationDialogAction(
+            label: tr.dialog_action_unsaved_changes_discard,
+            isDestructive: true,
+            onPressed: () => Navigator.pop(context, true),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
+++ b/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:studyu_designer_v2/common_views/confirmation_dialog.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
@@ -8,22 +7,20 @@ class UnsavedChangesDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PointerInterceptor(
-      child: StandardConfirmationDialog(
-        title: tr.dialog_unsaved_changes_title,
-        message: tr.dialog_unsaved_changes_description,
-        actions: [
-          ConfirmationDialogAction(
-            label: tr.dialog_action_unsaved_changes_stay,
-            onPressed: () => Navigator.pop(context, false),
-          ),
-          ConfirmationDialogAction(
-            label: tr.dialog_action_unsaved_changes_discard,
-            isDestructive: true,
-            onPressed: () => Navigator.pop(context, true),
-          ),
-        ],
-      ),
+    return StandardConfirmationDialog(
+      title: tr.dialog_unsaved_changes_title,
+      message: tr.dialog_unsaved_changes_description,
+      actions: [
+        ConfirmationDialogAction(
+          label: tr.dialog_action_unsaved_changes_stay,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        ConfirmationDialogAction(
+          label: tr.dialog_action_unsaved_changes_discard,
+          isDestructive: true,
+          onPressed: () => Navigator.pop(context, true),
+        ),
+      ],
     );
   }
 }

--- a/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
+++ b/designer_v2/lib/features/forms/unsaved_changes_dialog.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:studyu_designer_v2/common_views/dialog.dart';
-import 'package:studyu_designer_v2/common_views/primary_button.dart';
-import 'package:studyu_designer_v2/common_views/secondary_button.dart';
-import 'package:studyu_designer_v2/common_views/text_paragraph.dart';
+import 'package:studyu_designer_v2/common_views/confirmation_dialog.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
 class UnsavedChangesDialog extends StatelessWidget {
@@ -10,29 +7,20 @@ class UnsavedChangesDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StandardDialog(
-      titleText: tr.dialog_unsaved_changes_title,
-      body: TextParagraph(text: tr.dialog_unsaved_changes_description),
-      actionButtons: [
-        SecondaryButton(
-          onPressed: () {
-            Navigator.pop(context, true);
-          },
-          text: tr.dialog_action_unsaved_changes_discard,
-          icon: null,
-          minimumSize: const Size(120, 40),
+    return StandardConfirmationDialog(
+      title: tr.dialog_unsaved_changes_title,
+      message: tr.dialog_unsaved_changes_description,
+      actions: [
+        ConfirmationDialogAction(
+          label: tr.dialog_action_unsaved_changes_stay,
+          onPressed: () => Navigator.pop(context, false),
         ),
-        PrimaryButton(
-          onPressed: () {
-            Navigator.pop(context, false);
-          },
-          text: tr.dialog_action_unsaved_changes_stay,
-          icon: null,
-          minimumSize: const Size(120, 40),
+        ConfirmationDialogAction(
+          label: tr.dialog_action_unsaved_changes_discard,
+          isDestructive: true,
+          onPressed: () => Navigator.pop(context, true),
         ),
       ],
-      maxWidth: 500,
-      minHeight: 0,
     );
   }
 }

--- a/designer_v2/test/features/forms/unsaved_changes_dialog_test.dart
+++ b/designer_v2/test/features/forms/unsaved_changes_dialog_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_designer_v2/features/forms/unsaved_changes_dialog.dart';
+import 'package:studyu_designer_v2/localization/app_localizations_en.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
+
+void main() {
+  setUpAll(() {
+    AppTranslation.setForTesting(AppLocalizationsEn());
+  });
+
+  testWidgets('shows stay before a destructive discard action', (tester) async {
+    tester.view
+      ..physicalSize = const Size(1200, 800)
+      ..devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view
+        ..resetPhysicalSize()
+        ..resetDevicePixelRatio();
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: UnsavedChangesDialog()));
+
+    final stayButton = find.ancestor(
+      of: find.text('Stay'),
+      matching: find.byType(OutlinedButton),
+    );
+    final discardButton = find.ancestor(
+      of: find.text('Discard changes'),
+      matching: find.byType(ElevatedButton),
+    );
+
+    expect(stayButton, findsOneWidget);
+    expect(discardButton, findsOneWidget);
+    expect(
+      tester.getCenter(stayButton).dx,
+      lessThan(tester.getCenter(discardButton).dx),
+    );
+
+    final button = tester.widget<ElevatedButton>(discardButton);
+    final errorColor = Theme.of(
+      tester.element(discardButton),
+    ).colorScheme.error;
+    expect(button.style?.backgroundColor?.resolve({}), errorColor);
+  });
+}


### PR DESCRIPTION
## Description
Aligns the unsaved-changes confirmation with the Designer's delete dialogs. The safe action now appears as an outlined button on the left, while the destructive action appears as a red filled button on the right.

The dialog also intercepts browser pointer events so intervention and questionnaire previews no longer capture clicks through the modal.

## Visuals


<img width="523" height="245" alt="Screenshot 2026-07-13 at 14 14 35" src="https://github.com/user-attachments/assets/05280f2d-1a35-4cc7-bcca-b05e6632f6f8" />
<img width="526" height="269" alt="Screenshot 2026-07-13 at 14 14 48" src="https://github.com/user-attachments/assets/8596fc25-e1ba-4628-88a0-b981307f4ce9" />

## Testing Steps
1. Open an intervention or questionnaire form and make an unsaved change.
2. Attempt to leave the form.
3. Confirm that **Stay** is outlined on the left and **Discard changes** is red and filled on the right.
4. Position the dialog over the preview and confirm that both buttons remain clickable across the whole dialog.
5. Select **Stay** and confirm that the form remains open.
6. Reopen the dialog, select **Discard changes**, and confirm that the form closes without saving.

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analysis pass via `scripts/pre-commit-check`
- [x] Focused unsaved-changes widget test passes
- [ ] Screenshots attached
