### PR TITLE
fix(designer): keep questionnaire edits in local draft

### DIFF
--- a/designer_v2/integration_test/controller/robots/study_design_robot.dart
+++ b/designer_v2/integration_test/controller/robots/study_design_robot.dart
@@ -13,10 +13,7 @@ class StudyDesignRobot {
   }
 
   Future<void> validateChangesSaved() async {
-    // wait for 1s with future
-    //await Future.delayed(const Duration(seconds: 1));
-    //await $.pumpAndSettle(duration: const Duration(seconds: 1));
-    await $(Icons.check_circle_rounded).waitUntilVisible();
+    await $.pumpAndSettle(duration: const Duration(seconds: 1));
   }
 
   Future<void> validateStudyPublished() async {

--- a/designer_v2/integration_test/controller/robots/study_design_robot.dart
+++ b/designer_v2/integration_test/controller/robots/study_design_robot.dart
@@ -13,7 +13,7 @@ class StudyDesignRobot {
   }
 
   Future<void> validateChangesSaved() async {
-    await $.pumpAndSettle(duration: const Duration(seconds: 1));
+    await $(Icons.check_circle_rounded).waitUntilVisible();
   }
 
   Future<void> validateStudyPublished() async {

--- a/designer_v2/integration_test/controller/robots/study_measurements_robot.dart
+++ b/designer_v2/integration_test/controller/robots/study_measurements_robot.dart
@@ -21,14 +21,14 @@ class StudyMeasurementsRobot {
     await $(PrimaryButton)
         .which<PrimaryButton>((widget) => widget.text == tr.dialog_save)
         .last
-        .tap(settlePolicy: SettlePolicy.noSettle);
+        .tap();
   }
 
   Future<void> tapSaveSurveyQuestionButton() async {
     await $(PrimaryButton)
         .which<PrimaryButton>((widget) => widget.text == tr.dialog_save)
         .last
-        .tap(settlePolicy: SettlePolicy.noSettle);
+        .tap();
   }
 
   Future<void> enterSurveyName(String surveyName) async {

--- a/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/measurements_form_controller.dart
@@ -151,9 +151,14 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
 
   @override
   void onNewItem() {
-    final studyId = study.id;
+    final viewModel = provide(
+      MeasurementFormRouteArgs(
+        studyId: study.id,
+        measurementId: Config.newModelId,
+      ),
+    );
     router.dispatch(
-      RoutingIntents.studyEditMeasurement(studyId, Config.newModelId),
+      RoutingIntents.studyEditMeasurement(study.id, viewModel.measurementId),
     );
   }
 
@@ -162,14 +167,17 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
   @override
   MeasurementSurveyFormViewModel provide(MeasurementFormRouteArgs args) {
     if (args.measurementId.isNewId) {
-      // Eagerly add the managed viewmodel in case it needs to be [provide]d
-      // to a child controller
+      final existingDraft = surveyMeasurementFormViewModels.findWhere(
+        (viewModel) => viewModel.formMode == FormMode.create,
+      );
+      if (existingDraft != null) return existingDraft;
+
       final viewModel = MeasurementSurveyFormViewModel(
         study: study,
         delegate: this,
         validationSet: validationSet,
       );
-      surveyMeasurementFormViewModels.stage(viewModel);
+      surveyMeasurementFormViewModels.add(viewModel);
       return viewModel;
     }
 
@@ -189,7 +197,9 @@ class MeasurementsFormViewModel extends FormViewModel<MeasurementsFormData>
     MeasurementSurveyFormViewModel formViewModel,
     FormMode formMode,
   ) {
-    return; // no-op
+    if (formMode == FormMode.create) {
+      surveyMeasurementFormViewModels.remove(formViewModel);
+    }
   }
 
   @override

--- a/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_form_controller.dart
@@ -30,10 +30,7 @@ class MeasurementSurveyFormViewModel
     super.delegate,
     super.formData,
     super.validationSet = StudyFormValidationSet.draft,
-  }) {
-    // Persist survey changes when managed questions are added, edited, or removed.
-    propagateOnSave = true;
-  }
+  });
 
   final Study study;
 

--- a/designer_v2/lib/features/forms/form_view_model.dart
+++ b/designer_v2/lib/features/forms/form_view_model.dart
@@ -435,7 +435,7 @@ abstract class FormViewModel<T> implements IFormGroupController {
       // re-initialized, which re-triggers the valueChanges stream subscription
       // used for auto-saving (entering the infinite loop)
     }
-    delegate?.onSave(this, prevFormMode);
+    await delegate?.onSave(this, prevFormMode);
 
     // Put form into edit mode with saved data
     if (prevFormMode == FormMode.create) {

--- a/designer_v2/lib/features/study/study_controller_state.dart
+++ b/designer_v2/lib/features/study/study_controller_state.dart
@@ -101,7 +101,8 @@ class StudyControllerState extends StudyControllerBaseState
 
   @override
   bool get isSyncIndicatorVisible =>
-      studyStatus != null && studyStatus == StudyStatus.draft;
+      studyValue != null &&
+      (studyStatus == null || studyStatus == StudyStatus.draft);
 
   @override
   bool get isPublishVisible =>

--- a/designer_v2/lib/features/study/study_controller_state.dart
+++ b/designer_v2/lib/features/study/study_controller_state.dart
@@ -101,8 +101,7 @@ class StudyControllerState extends StudyControllerBaseState
 
   @override
   bool get isSyncIndicatorVisible =>
-      studyValue != null &&
-      (studyStatus == null || studyStatus == StudyStatus.draft);
+      studyStatus != null && studyStatus == StudyStatus.draft;
 
   @override
   bool get isPublishVisible =>

--- a/designer_v2/test/features/design/measurements/questionnaire_draft_test.dart
+++ b/designer_v2/test/features/design/measurements/questionnaire_draft_test.dart
@@ -1,0 +1,145 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/constants.dart';
+import 'package:studyu_designer_v2/features/design/measurements/measurements_form_controller.dart';
+import 'package:studyu_designer_v2/features/design/measurements/measurements_form_data.dart';
+import 'package:studyu_designer_v2/features/design/measurements/survey/survey_form_controller.dart';
+import 'package:studyu_designer_v2/features/design/measurements/survey/survey_form_data.dart';
+import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_data.dart';
+import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/question_type.dart';
+import 'package:studyu_designer_v2/features/design/shared/questionnaire/questionnaire_form_data.dart';
+import 'package:studyu_designer_v2/localization/app_localizations_en.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
+import 'package:studyu_designer_v2/routing/router_config.dart';
+
+void main() {
+  setUpAll(() => AppTranslation.setForTesting(AppLocalizationsEn()));
+
+  test(
+    'saving a question keeps the existing survey dirty until survey save',
+    () async {
+      final survey = MeasurementSurveyFormViewModel(
+        study: Study.withId('test-user'),
+        formData: _surveyData(),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final question = survey.questionModels.single;
+      question.questionTextControl.value = 'Changed question';
+      await question.save();
+
+      expect(survey.isDirty, isTrue);
+      expect(
+        survey
+            .formData!
+            .questionnaireFormData
+            .questionsData!
+            .single
+            .questionText,
+        'Original question',
+      );
+      expect(
+        survey
+            .buildFormData()
+            .questionnaireFormData
+            .questionsData!
+            .single
+            .questionText,
+        'Changed question',
+      );
+
+      await survey.cancel();
+
+      expect(
+        survey.questionModels.single.questionTextControl.value,
+        'Original question',
+      );
+    },
+  );
+
+  test('new survey stays local and is removed when cancelled', () async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const SizedBox.shrink(),
+        ),
+        GoRoute(
+          path: '/studies/:studyId/edit/measurements/:measurementId',
+          name: studyEditMeasurementRouteName,
+          builder: (context, state) => const SizedBox.shrink(),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    final measurements = MeasurementsFormViewModel(
+      study: Study.withId('test-user'),
+      router: router,
+      formData: MeasurementsFormData(surveyMeasurements: []),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    measurements.onNewItem();
+    await Future<void>.delayed(Duration.zero);
+
+    final survey = measurements.measurementViewModels.single;
+    expect(
+      router.routeInformationProvider.value.uri.pathSegments.last,
+      survey.measurementId,
+    );
+    final question = survey.provide(
+      SurveyQuestionFormRouteArgs(
+        studyId: 'study-1',
+        measurementId: survey.measurementId,
+        questionId: Config.newModelId,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    question.questionTextControl.value = 'Local question';
+    await question.save();
+
+    expect(survey.isDirty, isTrue);
+    expect(measurements.formData!.surveyMeasurements, isEmpty);
+    expect(
+      measurements
+          .buildFormData()
+          .surveyMeasurements
+          .single
+          .questionnaireFormData
+          .questionsData!
+          .single
+          .questionText,
+      'Local question',
+    );
+
+    await survey.cancel();
+
+    expect(measurements.measurementViewModels, isEmpty);
+    expect(measurements.buildFormData().surveyMeasurements, isEmpty);
+  });
+}
+
+MeasurementSurveyFormData _surveyData() {
+  return MeasurementSurveyFormData(
+    measurementId: 'survey-1',
+    instanceId: 'instance-1',
+    title: 'Survey',
+    questionnaireFormData: QuestionnaireFormData(
+      questionsData: [
+        BoolQuestionFormData(
+          questionId: 'question-1',
+          questionText: 'Original question',
+          questionType: SurveyQuestionType.bool,
+        ),
+      ],
+    ),
+    isTimeLocked: false,
+    hasReminder: false,
+  );
+}

--- a/designer_v2/test/features/forms/form_view_model_collection_actions_test.dart
+++ b/designer_v2/test/features/forms/form_view_model_collection_actions_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_data.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/question_type.dart';
@@ -22,7 +24,7 @@ class _TestFormData implements IFormData {
 }
 
 class _TestFormViewModel extends ManagedFormViewModel<_TestFormData> {
-  _TestFormViewModel({super.formData, this.duplicate});
+  _TestFormViewModel({super.formData, super.delegate, this.duplicate});
 
   final _TestFormViewModel? duplicate;
   final FormControl<String> valueControl = FormControl<String>(value: '');
@@ -56,9 +58,36 @@ class _TestFormViewModel extends ManagedFormViewModel<_TestFormData> {
   }
 }
 
+class _TestDelegate implements IFormViewModelDelegate<_TestFormViewModel> {
+  final saveCompleter = Completer<void>();
+
+  @override
+  void onCancel(_TestFormViewModel formViewModel, FormMode prevFormMode) {}
+
+  @override
+  Future<void> onSave(
+    _TestFormViewModel formViewModel,
+    FormMode prevFormMode,
+  ) => saveCompleter.future;
+}
+
 void main() {
   setUpAll(() {
     AppTranslation.setForTesting(AppLocalizationsEn());
+  });
+
+  test('save waits for its delegate', () async {
+    final delegate = _TestDelegate();
+    final viewModel = _TestFormViewModel(delegate: delegate);
+
+    var completed = false;
+    final save = viewModel.save().then((_) => completed = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completed, isFalse);
+    delegate.saveCompleter.complete();
+    await save;
+    expect(completed, isTrue);
   });
 
   test('duplicate action saves the duplicated view model', () async {


### PR DESCRIPTION
## Description
Keeps saved question edits in the survey's local questionnaire draft until the user saves the survey. Cancelling the survey now detects nested question changes, shows the discard warning, and restores the original questionnaire instead of retaining changes that were already written to the study.

New surveys are added to the local measurements collection before navigation and use their generated measurement ID immediately. This keeps them available to the local preview payload without restoring the `/measurements/new` reset bug fixed by #819. Cancelling a new survey removes that local draft.

## Visuals

https://github.com/user-attachments/assets/f8645bf2-8040-459c-8b1e-c9be65c3f71f

- [ ] Still missing:  4. Create and cancel a new survey while the preview uses its local draft.


## Testing Steps
1. Open an existing measurement survey and edit a question.
2. Save the question, then cancel the survey.
3. Confirm that the discard warning appears.
4. Choose **Stay** and confirm that the edited question remains in the local survey draft.
5. Cancel again, choose **Discard changes**, and confirm that the original question is restored.
6. Create a new survey and add a question.
7. Confirm that the preview uses the new survey and question before the survey is saved.
8. Cancel and discard the new survey, then confirm that it does not appear in the measurements list.
9. Repeat the new-survey flow and save the survey, then confirm that it remains available after reopening the study.

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analysis pass via `scripts/pre-commit-check`
- [x] Questionnaire draft regression tests pass in Chrome
- [x] Default measurements tests pass
- [ ] Screen recording attached
