### PR TITLE
fix(app): stop eligibility flow on failed answer

### DIFF
--- a/app/lib/screens/study/onboarding/eligibility_screen.dart
+++ b/app/lib/screens/study/onboarding/eligibility_screen.dart
@@ -35,6 +35,7 @@ class EligibilityScreen extends StatefulWidget {
 class _EligibilityScreenState extends State<EligibilityScreen> {
   EligibilityResult? activeResult;
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+  bool _ignoreNextNullResponse = false;
 
   @override
   void initState() {
@@ -62,6 +63,8 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
       (element) => element.isViolated(qs),
     );
     if (failingResult == null) return true;
+    // QuestionnaireWidget reports null after the continuation predicate stops.
+    _ignoreNextNullResponse = true;
     // freetext quickfix start
     // failingResult = _isFreeTextCriterion(failingResult) ? null : failingResult;
     // freetext quickfix end
@@ -77,6 +80,10 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
 
   void _evaluateResponse(QuestionnaireState? qs) {
     if (qs == null) {
+      if (_ignoreNextNullResponse) {
+        _ignoreNextNullResponse = false;
+        return;
+      }
       _invalidateResponse();
       return;
     }
@@ -199,6 +206,7 @@ class _EligibilityScreenState extends State<EligibilityScreen> {
               title: widget.study!.title,
               onComplete: _evaluateResponse,
               shouldContinue: _checkContinuation,
+              hideCta: activeResult?.eligible == false,
             ),
           ),
           if (activeResult != null) _constructResultBanner(),

--- a/app/lib/widgets/questionnaire/questionnaire_widget.dart
+++ b/app/lib/widgets/questionnaire/questionnaire_widget.dart
@@ -23,6 +23,7 @@ class QuestionnaireWidget extends StatefulWidget {
   /// When true, the global CTA shows a loading spinner and is disabled.
   /// The parent sets this while it processes a completed submission.
   final bool isSubmitting;
+  final bool hideCta;
 
   const QuestionnaireWidget(
     this.questions, {
@@ -33,6 +34,7 @@ class QuestionnaireWidget extends StatefulWidget {
     this.onComplete,
     this.shouldContinue,
     this.isSubmitting = false,
+    this.hideCta = false,
     super.key,
   });
 
@@ -418,7 +420,7 @@ class QuestionnaireWidgetState extends State<QuestionnaireWidget> {
     final ctaMode = _controller.ctaModeFor(
       shownQuestions.map((c) => c.question),
     );
-    final showCta = ctaMode != QuestionnaireCtaMode.hidden;
+    final showCta = !widget.hideCta && ctaMode != QuestionnaireCtaMode.hidden;
 
     return Column(
       children: [

--- a/app/test/screens/study/onboarding/eligibility_screen_test.dart
+++ b/app/test/screens/study/onboarding/eligibility_screen_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/screens/study/onboarding/eligibility_screen.dart';
+import 'package:studyu_core/core.dart';
+
+void main() {
+  testWidgets('shows failed eligibility immediately after the answer', (
+    tester,
+  ) async {
+    final question = BooleanQuestion.withId()
+      ..id = 'eligible'
+      ..prompt = 'Do you fulfill the criterion?';
+    final criterion = EligibilityCriterion.withId()
+      ..reason = 'Criterion not fulfilled'
+      ..condition = (BooleanExpression()..target = question.id);
+    final study = Study.withId('user')
+      ..title = 'Study'
+      ..questionnaire.questions = [question]
+      ..eligibilityCriteria = [criterion];
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => EligibilityScreen(study: study),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        locale: const Locale('en'),
+        routerConfig: router,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('no'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('You are not eligible for this study'), findsOneWidget);
+    expect(find.text('Criterion not fulfilled'), findsOneWidget);
+    expect(find.text('Complete'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Description
Eligibility criteria were evaluated after each answer, but the questionnaire's null completion callback cleared the failed result immediately. Keep that failed result, show the ineligible banner after the disqualifying answer, and hide the questionnaire's Complete button while eligibility has failed.

## Testing Steps
1. Open a study with a boolean eligibility criterion.
2. Select the answer that violates the criterion.
3. Confirm the ineligible banner appears immediately.
4. Confirm the Complete button is not shown.

Automated checks:
- [x] `scripts/pre-commit-check`
- [x] `cd app && rtk fvm flutter test test/screens/study/onboarding/eligibility_screen_test.dart`
- [x] `cd app && rtk fvm flutter test test/widgets/questionnaire/questionnaire_widget_test.dart`

### PR Checklist
- [x] Formatting passes
- [x] Analyzer passes
