### PR TITLE
fix(designer): enable copying study names in confirmations

### DIFF
--- a/designer_v2/lib/common_views/study_title_confirmation_dialog.dart
+++ b/designer_v2/lib/common_views/study_title_confirmation_dialog.dart
@@ -79,88 +79,90 @@ class _StudyTitleConfirmationDialogState
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return StandardDialog(
-      titleText: widget.title,
-      body: Form(
-        key: _formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SelectableText(widget.description),
-            ...widget.additionalContent,
-            if (widget.confirmationCheckboxes.isNotEmpty) ...[
-              const SizedBox(height: 16.0),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  border: Border.all(color: colorScheme.outlineVariant),
-                  borderRadius: BorderRadius.circular(8.0),
-                ),
-                child: Material(
-                  color: Colors.transparent,
-                  child: Column(
-                    children: [
-                      for (final checkbox in widget.confirmationCheckboxes)
-                        CheckboxListTile(
-                          key: checkbox.key,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 12.0,
+    return SelectionArea(
+      child: StandardDialog(
+        titleText: widget.title,
+        body: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SelectableText(widget.description),
+              ...widget.additionalContent,
+              if (widget.confirmationCheckboxes.isNotEmpty) ...[
+                const SizedBox(height: 16.0),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: colorScheme.outlineVariant),
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Material(
+                    color: Colors.transparent,
+                    child: Column(
+                      children: [
+                        for (final checkbox in widget.confirmationCheckboxes)
+                          CheckboxListTile(
+                            key: checkbox.key,
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 12.0,
+                            ),
+                            controlAffinity: ListTileControlAffinity.leading,
+                            value: _checkedConfirmationKeys.contains(
+                              checkbox.key,
+                            ),
+                            onChanged: (value) {
+                              setState(() {
+                                if (value ?? false) {
+                                  _checkedConfirmationKeys.add(checkbox.key);
+                                } else {
+                                  _checkedConfirmationKeys.remove(checkbox.key);
+                                }
+                              });
+                            },
+                            title: checkbox.label,
                           ),
-                          controlAffinity: ListTileControlAffinity.leading,
-                          value: _checkedConfirmationKeys.contains(
-                            checkbox.key,
-                          ),
-                          onChanged: (value) {
-                            setState(() {
-                              if (value ?? false) {
-                                _checkedConfirmationKeys.add(checkbox.key);
-                              } else {
-                                _checkedConfirmationKeys.remove(checkbox.key);
-                              }
-                            });
-                          },
-                          title: checkbox.label,
-                        ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
+              ],
+              const SizedBox(height: 16.0),
+              SelectableText(widget.instruction),
+              const SizedBox(height: 16.0),
+              TextFormField(
+                key: widget.textFieldKey,
+                controller: _studyTitleController,
+                decoration: InputDecoration(labelText: widget.textFieldLabel),
+                validator: (value) {
+                  if (value == null || value != _studyTitle) {
+                    return tr.dialog_study_title_mismatch;
+                  }
+                  return null;
+                },
               ),
             ],
-            const SizedBox(height: 16.0),
-            SelectableText(widget.instruction),
-            const SizedBox(height: 16.0),
-            TextFormField(
-              key: widget.textFieldKey,
-              controller: _studyTitleController,
-              decoration: InputDecoration(labelText: widget.textFieldLabel),
-              validator: (value) {
-                if (value == null || value != _studyTitle) {
-                  return tr.dialog_study_title_mismatch;
+          ),
+        ),
+        actionButtons: [
+          const DismissButton(),
+          if (!widget.hideConfirmUntilValid || _canConfirm)
+            PrimaryButton(
+              text: widget.confirmLabel,
+              icon: null,
+              enabled: _canConfirm,
+              backgroundColor: widget.destructive ? colorScheme.error : null,
+              foregroundColor: widget.destructive ? colorScheme.onError : null,
+              onPressedFuture: () async {
+                if (_formKey.currentState!.validate()) {
+                  await widget.onConfirmed();
                 }
-                return null;
               },
             ),
-          ],
-        ),
+        ],
+        maxWidth: 650,
+        minWidth: 610,
+        minHeight: 200,
       ),
-      actionButtons: [
-        const DismissButton(),
-        if (!widget.hideConfirmUntilValid || _canConfirm)
-          PrimaryButton(
-            text: widget.confirmLabel,
-            icon: null,
-            enabled: _canConfirm,
-            backgroundColor: widget.destructive ? colorScheme.error : null,
-            foregroundColor: widget.destructive ? colorScheme.onError : null,
-            onPressedFuture: () async {
-              if (_formKey.currentState!.validate()) {
-                await widget.onConfirmed();
-              }
-            },
-          ),
-      ],
-      maxWidth: 650,
-      minWidth: 610,
-      minHeight: 200,
     );
   }
 }


### PR DESCRIPTION
## Description
The study name shown in the delete and close confirmation dialogs could not be reliably selected and copied in Flutter Web. The shared confirmation dialog was missing a SelectionArea around its scrollable content.

## Visuals
Please attach a screenshot or short screen recording showing selecting the study name in the confirmation dialog and pasting it into the field before merging.

## Testing Steps
1. Open a study in Designer v2.
2. Open the close-participation confirmation popup and select/copy the displayed study name.
3. Paste it into the title field and verify confirmation becomes available after the required checkbox is selected.
4. Repeat with the permanently-delete popup.
5. Run scripts/pre-commit-check.

### PR Checklist
- [x] Formatting and analyzer checks pass
- [ ] fvm exec melos qualitycheck passes
- [ ] Screenshot or video attached for this visual/interactive change
- [ ] Description links a related issue, or this item is removed when no issue exists