### PR TITLE
fix: enforce study availability during testing

### DIFF
--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -49,7 +49,7 @@ class AppState with ChangeNotifier {
     // todo baseline
     study.schedule.includeBaseline = false;
     selectedStudy = study;
-    if (activeSubject!.study.id == study.id) {
+    if (activeSubject?.study.id == study.id) {
       activeSubject!.study = study;
     }
     notifyListeners();

--- a/app/lib/screens/app_onboarding/iframe_helper.dart
+++ b/app/lib/screens/app_onboarding/iframe_helper.dart
@@ -9,6 +9,8 @@ import "package:universal_html/html.dart" as html;
 typedef PreviewNavigationHandler = Future<void> Function(String? route);
 
 class IFrameHelper {
+  // The listener must outlive LoadingScreen so loaded preview routes keep
+  // receiving live study updates from the Designer.
   static StreamSubscription<html.MessageEvent>? _messageSubscription;
 
   String? _designerOrigin() {
@@ -51,11 +53,6 @@ class IFrameHelper {
     if (designerOrigin == null) return;
 
     parent.postMessage(message, designerOrigin);
-  }
-
-  static void cancelSubscription() {
-    _messageSubscription?.cancel();
-    _messageSubscription = null;
   }
 
   void listen(AppState state, {PreviewNavigationHandler? onNavigate}) {

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -718,12 +718,6 @@ class _LoadingScreenState extends State<LoadingScreen> {
   }
 
   @override
-  void dispose() {
-    IFrameHelper.cancelSubscription();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     if (kIsWeb && widget.hasDeepLink) {
       return DeepLinkWebLandingPage(

--- a/app/test/models/app_state_test.dart
+++ b/app/test/models/app_state_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_core/core.dart';
+
+void main() {
+  test('preview study can update before a subject is created', () {
+    final state = AppState();
+    final study = Study('study', 'user');
+
+    expect(() => state.updateStudy(study), returnsNormally);
+    expect(state.selectedStudy, same(study));
+  });
+}

--- a/designer_v2/lib/features/design/interventions/intervention_preview_view.dart
+++ b/designer_v2/lib/features/design/interventions/intervention_preview_view.dart
@@ -28,7 +28,8 @@ class InterventionPreview extends ConsumerWidget {
               ],
             ),
           ),
-          previewBanner(ref, routeArgs.studyId) ?? const SizedBox.shrink(),
+          if (previewBanner(ref, routeArgs.studyId) case final banner?)
+            Positioned(top: 0, left: 0, right: 0, child: banner),
         ],
       ),
     );

--- a/designer_v2/lib/features/design/interventions/interventions_form_controller.dart
+++ b/designer_v2/lib/features/design/interventions/interventions_form_controller.dart
@@ -159,9 +159,14 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
 
   @override
   void onNewItem() {
-    final studyId = study.id;
+    final viewModel = provide(
+      InterventionFormRouteArgs(
+        studyId: study.id,
+        interventionId: Config.newModelId,
+      ),
+    );
     router.dispatch(
-      RoutingIntents.studyEditIntervention(studyId, Config.newModelId),
+      RoutingIntents.studyEditIntervention(study.id, viewModel.interventionId),
     );
   }
 
@@ -171,14 +176,17 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
   @override
   InterventionFormViewModel provide(InterventionFormRouteArgs args) {
     if (args.interventionId.isNewId) {
-      // Eagerly add the managed viewmodel in case it needs to be [provide]d
-      // to a child controller
+      final existingDraft = interventionsCollection.findWhere(
+        (viewModel) => viewModel.formMode == FormMode.create,
+      );
+      if (existingDraft != null) return existingDraft;
+
       final viewModel = InterventionFormViewModel(
         study: study,
         delegate: this,
         validationSet: validationSet,
       );
-      interventionsCollection.stage(viewModel);
+      interventionsCollection.add(viewModel);
       return viewModel;
     }
 
@@ -195,7 +203,9 @@ class InterventionsFormViewModel extends FormViewModel<InterventionsFormData>
 
   @override
   void onCancel(InterventionFormViewModel formViewModel, FormMode formMode) {
-    return; // no-op
+    if (formMode == FormMode.create) {
+      interventionsCollection.remove(formViewModel);
+    }
   }
 
   @override

--- a/designer_v2/lib/features/design/measurements/survey/survey_preview_view.dart
+++ b/designer_v2/lib/features/design/measurements/survey/survey_preview_view.dart
@@ -28,7 +28,8 @@ class SurveyPreview extends ConsumerWidget {
               ],
             ),
           ),
-          previewBanner(ref, routeArgs.studyId) ?? const SizedBox.shrink(),
+          if (previewBanner(ref, routeArgs.studyId) case final banner?)
+            Positioned(top: 0, left: 0, right: 0, child: banner),
         ],
       ),
     );

--- a/designer_v2/lib/features/design/study_form_providers.dart
+++ b/designer_v2/lib/features/design/study_form_providers.dart
@@ -154,7 +154,12 @@ StudyFormViewModel studyPublishValidator(Ref ref, StudyID studyId) {
 /// a [StudyFormValidationSet.test]
 @riverpod
 StudyFormViewModel studyTestValidator(Ref ref, StudyID studyId) {
-  final state = ref.watch(studyControllerProvider(studyId));
+  final formViewModel = ref.watch(studyFormViewModelProvider(studyId));
+  final subscription = formViewModel.form.valueChanges.listen(
+    (_) => ref.invalidateSelf(),
+  );
+  ref.onDispose(subscription.cancel);
+
   return StudyFormViewModel(
     router: ref.watch(routerProvider),
     studyRepository: ref.watch(studyRepositoryProvider),
@@ -162,6 +167,7 @@ StudyFormViewModel studyTestValidator(Ref ref, StudyID studyId) {
     fitbitCredentialsRepository: ref.watch(
       fitbitCredentialsRepositoryProvider(studyId),
     ),
-    formData: state.studyValueRequired,
+    formData: formViewModel.buildFormData(),
+    validationSet: StudyFormValidationSet.test,
   );
 }

--- a/designer_v2/lib/features/design/study_form_providers.g.dart
+++ b/designer_v2/lib/features/design/study_form_providers.g.dart
@@ -1236,7 +1236,7 @@ final class StudyTestValidatorProvider
 }
 
 String _$studyTestValidatorHash() =>
-    r'd358126f42627ef3ac1b2817c6e13fff800129bc';
+    r'c7c697b8302808a287fab879a7e6b3f2878829e7';
 
 /// Provides the [StudyFormViewModel] for validation purposes with
 /// a [StudyFormValidationSet.test]

--- a/designer_v2/lib/features/study/study_test_frame.dart
+++ b/designer_v2/lib/features/study/study_test_frame.dart
@@ -102,8 +102,14 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
 
   void _updatePreviewRoute() {
     if (_activeFrameController == null) return;
+    final data = jsonEncode(
+      ref
+          .read(studyFormViewModelProvider(widget.studyId))
+          .buildFormData()
+          .toJson(),
+    );
     if (widget.route != null) {
-      _activeFrameController!.generateUrl(route: widget.route);
+      _activeFrameController!.generateUrl(route: widget.route, data: data);
     } else {
       String route = 'default';
 
@@ -113,15 +119,20 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
           route: route,
           extra:
               (widget.routeArgs! as InterventionFormRouteArgs).interventionId,
+          data: data,
         );
       } else if (widget.routeArgs is MeasurementFormRouteArgs) {
         route = 'observation';
         _activeFrameController!.generateUrl(
           route: route,
           extra: (widget.routeArgs! as MeasurementFormRouteArgs).measurementId,
+          data: data,
         );
       } else {
-        _activeFrameController!.generateUrl(route: TestAppRoutes.studyOverview);
+        _activeFrameController!.generateUrl(
+          route: TestAppRoutes.studyOverview,
+          data: data,
+        );
       }
     }
   }
@@ -278,7 +289,9 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
     frameController = ref.watch(
       studyTestPlatformControllerProvider(widget.studyId),
     );
-    _ensureFrameController();
+    if (!formViewModel.form.hasErrors) {
+      _ensureFrameController();
+    }
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/designer_v2/lib/features/study/study_test_frame.dart
+++ b/designer_v2/lib/features/study/study_test_frame.dart
@@ -110,9 +110,8 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
       final formJson = jsonEncode(
         formViewModelCurrent.buildFormData().toJson(),
       );
-      controller.routeInformation.data = formJson;
       try {
-        controller.send(formJson);
+        controller.updateData(formJson);
       } catch (_) {
         // The preview iframe may reload while form changes are emitted.
       }

--- a/designer_v2/lib/features/study/study_test_frame.dart
+++ b/designer_v2/lib/features/study/study_test_frame.dart
@@ -37,6 +37,23 @@ class PreviewFrame extends ConsumerStatefulWidget {
   ConsumerState<PreviewFrame> createState() => _PreviewFrameState();
 }
 
+@visibleForTesting
+({String route, String? extra}) previewRouteTarget(PreviewFrame frame) {
+  if (frame.route != null) return (route: frame.route!, extra: null);
+
+  return switch (frame.routeArgs) {
+    final InterventionFormRouteArgs args => (
+      route: 'intervention',
+      extra: args.interventionId,
+    ),
+    final MeasurementFormRouteArgs args => (
+      route: 'observation',
+      extra: args.measurementId,
+    ),
+    _ => (route: TestAppRoutes.studyOverview, extra: null),
+  };
+}
+
 class _PreviewFrameState extends ConsumerState<PreviewFrame> {
   static const Duration _healthCheckTimeout = Duration(seconds: 5);
   PlatformController? frameController;
@@ -87,54 +104,37 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
     _formChangesSubscription = formViewModelCurrent.form.valueChanges.listen((
       event,
     ) {
-      if (frameController != null) {
-        final formJson = jsonEncode(
-          formViewModelCurrent.buildFormData().toJson(),
-        );
-        try {
-          frameController!.send(formJson);
-        } catch (_) {
-          // The preview iframe may reload while form changes are emitted.
-        }
+      final controller = _activeFrameController;
+      if (controller == null) return;
+
+      final formJson = jsonEncode(
+        formViewModelCurrent.buildFormData().toJson(),
+      );
+      controller.routeInformation.data = formJson;
+      try {
+        controller.send(formJson);
+      } catch (_) {
+        // The preview iframe may reload while form changes are emitted.
       }
     });
   }
 
   void _updatePreviewRoute() {
-    if (_activeFrameController == null) return;
+    final controller = _activeFrameController;
+    if (controller == null) return;
+
     final data = jsonEncode(
       ref
           .read(studyFormViewModelProvider(widget.studyId))
           .buildFormData()
           .toJson(),
     );
-    if (widget.route != null) {
-      _activeFrameController!.generateUrl(route: widget.route, data: data);
-    } else {
-      String route = 'default';
-
-      if (widget.routeArgs is InterventionFormRouteArgs) {
-        route = 'intervention';
-        _activeFrameController!.generateUrl(
-          route: route,
-          extra:
-              (widget.routeArgs! as InterventionFormRouteArgs).interventionId,
-          data: data,
-        );
-      } else if (widget.routeArgs is MeasurementFormRouteArgs) {
-        route = 'observation';
-        _activeFrameController!.generateUrl(
-          route: route,
-          extra: (widget.routeArgs! as MeasurementFormRouteArgs).measurementId,
-          data: data,
-        );
-      } else {
-        _activeFrameController!.generateUrl(
-          route: TestAppRoutes.studyOverview,
-          data: data,
-        );
-      }
-    }
+    final target = previewRouteTarget(widget);
+    controller.generateUrl(
+      route: target.route,
+      extra: target.extra,
+      data: data,
+    );
   }
 
   Uri? _configuredAppUri(String appUrl) => Uri.tryParse(appUrl);
@@ -268,7 +268,10 @@ class _PreviewFrameState extends ConsumerState<PreviewFrame> {
   @override
   void didUpdateWidget(covariant PreviewFrame oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_activeFrameController == null) return;
+    if (_activeFrameController == null ||
+        previewRouteTarget(widget) == previewRouteTarget(oldWidget)) {
+      return;
+    }
 
     _updatePreviewRoute();
     final nextPreviewUrl = _activeFrameController!.previewSrc;

--- a/designer_v2/lib/features/study/study_test_frame_controllers.dart
+++ b/designer_v2/lib/features/study/study_test_frame_controllers.dart
@@ -173,7 +173,7 @@ class WebController extends PlatformController {
       previewSrc = "$previewSrc&cmd=$cmd";
     }
     if (data != null) {
-      previewSrc = "$previewSrc&data=$data";
+      previewSrc = "$previewSrc&data=${Uri.encodeQueryComponent(data)}";
     }
   }
 
@@ -207,14 +207,19 @@ class WebController extends PlatformController {
           route: routeInformation.route,
           extra: routeInformation.extra,
           cmd: cmd,
+          data: routeInformation.data,
         );
         return;
       }
-      navigate(route: routeInformation.route, cmd: cmd);
+      navigate(
+        route: routeInformation.route,
+        cmd: cmd,
+        data: routeInformation.data,
+      );
       return;
     }
 
-    navigate(cmd: cmd);
+    navigate(cmd: cmd, data: routeInformation.data);
     return;
   }
 

--- a/designer_v2/lib/features/study/study_test_frame_controllers.dart
+++ b/designer_v2/lib/features/study/study_test_frame_controllers.dart
@@ -99,6 +99,11 @@ abstract class PlatformController {
   void navigate({String? route, String? extra, String? cmd, String? data});
   void refresh({String? cmd});
   void listen();
+  void updateData(String data) {
+    routeInformation.data = data;
+    send(data);
+  }
+
   void send(String message);
   void openNewPage() {}
   void dispose() {}
@@ -153,28 +158,47 @@ class WebController extends PlatformController {
     );
   }
 
+  String _buildPreviewUrl({
+    String? route,
+    String? extra,
+    String? cmd,
+    String? data,
+  }) {
+    if (baseSrc == '') return '';
+
+    var url = baseSrc;
+    if (route != null) url = "$url&route=$route";
+    if (extra != null) url = "$url&extra=$extra";
+    if (cmd != null) url = "$url&cmd=$cmd";
+    if (data != null) {
+      url = "$url&data=${Uri.encodeQueryComponent(data)}";
+    }
+    return url;
+  }
+
   @override
   void generateUrl({String? route, String? extra, String? cmd, String? data}) {
     onLoadStarted?.call();
     navigationEnabled.value = false;
     routeInformation = RouteInformation(route, extra, cmd, data);
-    if (baseSrc == '') {
-      previewSrc = '';
-      return;
-    }
-    previewSrc = baseSrc;
-    if (route != null) {
-      previewSrc = "$previewSrc&route=$route";
-    }
-    if (extra != null) {
-      previewSrc = "$previewSrc&extra=$extra";
-    }
-    if (cmd != null) {
-      previewSrc = "$previewSrc&cmd=$cmd";
-    }
-    if (data != null) {
-      previewSrc = "$previewSrc&data=${Uri.encodeQueryComponent(data)}";
-    }
+    previewSrc = _buildPreviewUrl(
+      route: route,
+      extra: extra,
+      cmd: cmd,
+      data: data,
+    );
+  }
+
+  @override
+  void updateData(String data) {
+    routeInformation.data = data;
+    previewSrc = _buildPreviewUrl(
+      route: routeInformation.route,
+      extra: routeInformation.extra,
+      cmd: routeInformation.cmd,
+      data: data,
+    );
+    if (_isListening) send(data);
   }
 
   @override

--- a/designer_v2/test/features/design/interventions/intervention_draft_test.dart
+++ b/designer_v2/test/features/design/interventions/intervention_draft_test.dart
@@ -1,0 +1,55 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_designer_v2/constants.dart';
+import 'package:studyu_designer_v2/features/design/interventions/interventions_form_controller.dart';
+import 'package:studyu_designer_v2/features/design/interventions/interventions_form_data.dart';
+import 'package:studyu_designer_v2/localization/app_localizations_en.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
+
+void main() {
+  setUpAll(() => AppTranslation.setForTesting(AppLocalizationsEn()));
+
+  test('new intervention is included until cancelled', () async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const SizedBox.shrink(),
+        ),
+        GoRoute(
+          path: '/studies/:studyId/edit/interventions/:interventionId',
+          name: studyEditInterventionRouteName,
+          builder: (context, state) => const SizedBox.shrink(),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    final study = Study.withId('test-user')
+      ..interventions = [Intervention('intervention-1', 'Intervention 1')];
+    final interventions = InterventionsFormViewModel(
+      study: study,
+      router: router,
+      formData: InterventionsFormData.fromStudy(study),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    interventions.onNewItem();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(interventions.interventionsArray.controls, hasLength(2));
+    final draft = interventions.interventionsCollection.formViewModels.last;
+    expect(
+      router.routeInformationProvider.value.uri.pathSegments.last,
+      draft.interventionId,
+    );
+
+    await draft.cancel();
+
+    expect(interventions.interventionsArray.controls, hasLength(1));
+  });
+}

--- a/designer_v2/test/features/study/study_test_frame_test.dart
+++ b/designer_v2/test/features/study/study_test_frame_test.dart
@@ -1,0 +1,42 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_designer_v2/features/study/study_test_frame.dart';
+import 'package:studyu_designer_v2/routing/router_config.dart';
+
+void main() {
+  test('form rebuilds keep the loaded intervention preview route', () {
+    final initial = previewRouteTarget(
+      PreviewFrame(
+        'study',
+        routeArgs: InterventionFormRouteArgs(
+          studyId: 'study',
+          interventionId: 'intervention-1',
+        ),
+      ),
+    );
+    final editedTask = previewRouteTarget(
+      PreviewFrame(
+        'study',
+        routeArgs: InterventionTaskFormRouteArgs(
+          studyId: 'study',
+          interventionId: 'intervention-1',
+          taskId: 'task-2',
+        ),
+      ),
+    );
+    final otherIntervention = previewRouteTarget(
+      PreviewFrame(
+        'study',
+        routeArgs: InterventionFormRouteArgs(
+          studyId: 'study',
+          interventionId: 'intervention-2',
+        ),
+      ),
+    );
+
+    expect(editedTask, initial);
+    expect(otherIntervention, isNot(initial));
+  });
+}

--- a/designer_v2/test/features/study/study_test_frame_test.dart
+++ b/designer_v2/test/features/study/study_test_frame_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_designer_v2/features/study/study_test_frame.dart';
+import 'package:studyu_designer_v2/features/study/study_test_frame_controllers.dart';
 import 'package:studyu_designer_v2/routing/router_config.dart';
 
 void main() {
@@ -38,5 +39,24 @@ void main() {
 
     expect(editedTask, initial);
     expect(otherIntervention, isNot(initial));
+  });
+
+  test('live edits update the URL used to open the preview', () {
+    final controller =
+        WebController('https://app.example/?studyid=study', 'study')
+          ..generateUrl(
+            route: 'intervention',
+            extra: 'intervention-1',
+            cmd: 'reset',
+            data: '{"title":"old"}',
+          );
+
+    controller.updateData('{"title":"edited"}');
+
+    final parameters = Uri.parse(controller.previewSrc).queryParameters;
+    expect(parameters['route'], 'intervention');
+    expect(parameters['extra'], 'intervention-1');
+    expect(parameters['cmd'], 'reset');
+    expect(parameters['data'], '{"title":"edited"}');
   });
 }


### PR DESCRIPTION
## Description
Prevent studies with fewer than two interventions from entering participant flows that require a valid crossover schedule. The participant app redirects unavailable studies to a dedicated screen, while the Designer applies its existing test validation rules to live, unsaved study data.

The Designer preview now keeps draft interventions in the live form, updates its warning banner and disabled phone frame immediately, and initializes the iframe with the current draft study. Subsequent form edits are sent to the loaded iframe without changing its URL, so the preview updates in real time without showing loading overlays or stealing input focus. Preview reset and refresh operations preserve the latest draft data instead of falling back to the saved backend version.

## Visuals

https://github.com/user-attachments/assets/e4a09c96-1ad1-44b4-b5ca-2280eeb52bd6


## Testing Steps
1. Open a draft study containing one intervention and navigate to the Designer test page or a split intervention/questionnaire preview.
2. Verify the warning banner and disabled phone frame are shown.
3. Click **Add intervention** without saving the study.
4. Verify the banner disappears and the phone preview opens using the new unnamed intervention.
5. Continue typing in the intervention title and description, then add or edit an intervention task. Verify the preview updates in real time without showing another loading overlay or moving focus away from the input.
6. Cancel the draft intervention and verify the warning state returns.

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Analyzer passes via `scripts/pre-commit-check`
- [ ] `fvm exec melos qualitycheck` passes
- [x] Screenshot or video attached

