### PR TITLE
STUDYU-57 fix(flutter_common): isolate debug storage by environment

### DIFF
--- a/flutter_common/lib/src/utils/env_loader.dart
+++ b/flutter_common/lib/src/utils/env_loader.dart
@@ -72,7 +72,7 @@ Future<void> loadEnv() async {
     url: workingSupabaseUrl,
     publishableKey: supabaseAnonKey,
     authOptions: FlutterAuthClientOptions(
-      localStorage: SupabaseStorage(workingSupabaseUrl),
+      localStorage: SupabaseStorage(kDebugMode ? workingSupabaseUrl : null),
     ),
     debug: true,
   );

--- a/flutter_common/lib/src/utils/env_loader.dart
+++ b/flutter_common/lib/src/utils/env_loader.dart
@@ -8,11 +8,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 const envsAssetPath = 'packages/studyu_flutter_common/lib/envs';
 
-// load env from envs/.env or from the filename specified in the STUDYU_ENV runtime-variable
-String envFilePath() {
+String envFileName() {
   const env = String.fromEnvironment('STUDYU_ENV');
-  return env.isNotEmpty ? '$envsAssetPath/$env' : '$envsAssetPath/.env';
+  return env.isNotEmpty ? env : '.env';
 }
+
+// load env from envs/.env or from the filename specified in the STUDYU_ENV runtime-variable
+String envFilePath() => '$envsAssetPath/${envFileName()}';
 
 String? getEnv(String name, {bool optional = false}) {
   final value = dotenv.env[name];
@@ -40,6 +42,7 @@ String? getEnv(String name, {bool optional = false}) {
 
 Future<void> loadEnv() async {
   await dotenv.load(fileName: envFilePath());
+  SecureStorage.environment = envFileName();
   final supabaseUrls = loadSupabaseUrls();
 
   final supabaseAnonKey = getEnv('STUDYU_SUPABASE_PUBLIC_ANON_KEY');
@@ -71,9 +74,7 @@ Future<void> loadEnv() async {
   await Supabase.initialize(
     url: workingSupabaseUrl,
     publishableKey: supabaseAnonKey,
-    authOptions: FlutterAuthClientOptions(
-      localStorage: SupabaseStorage(kDebugMode ? envFilePath() : null),
-    ),
+    authOptions: FlutterAuthClientOptions(localStorage: SupabaseStorage()),
     debug: true,
   );
 

--- a/flutter_common/lib/src/utils/env_loader.dart
+++ b/flutter_common/lib/src/utils/env_loader.dart
@@ -71,7 +71,9 @@ Future<void> loadEnv() async {
   await Supabase.initialize(
     url: workingSupabaseUrl,
     publishableKey: supabaseAnonKey,
-    authOptions: FlutterAuthClientOptions(localStorage: SupabaseStorage()),
+    authOptions: FlutterAuthClientOptions(
+      localStorage: SupabaseStorage(workingSupabaseUrl),
+    ),
     debug: true,
   );
 

--- a/flutter_common/lib/src/utils/env_loader.dart
+++ b/flutter_common/lib/src/utils/env_loader.dart
@@ -72,7 +72,7 @@ Future<void> loadEnv() async {
     url: workingSupabaseUrl,
     publishableKey: supabaseAnonKey,
     authOptions: FlutterAuthClientOptions(
-      localStorage: SupabaseStorage(kDebugMode ? workingSupabaseUrl : null),
+      localStorage: SupabaseStorage(kDebugMode ? envFilePath() : null),
     ),
     debug: true,
   );

--- a/flutter_common/lib/src/utils/env_loader.dart
+++ b/flutter_common/lib/src/utils/env_loader.dart
@@ -41,8 +41,11 @@ String? getEnv(String name, {bool optional = false}) {
 }
 
 Future<void> loadEnv() async {
+  SecureStorage.environment = effectiveStorageEnvironment(
+    envFileName(),
+    isDebug: kDebugMode,
+  );
   await dotenv.load(fileName: envFilePath());
-  SecureStorage.environment = envFileName();
   final supabaseUrls = loadSupabaseUrls();
 
   final supabaseAnonKey = getEnv('STUDYU_SUPABASE_PUBLIC_ANON_KEY');

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -7,6 +7,13 @@ import 'package:synchronized/synchronized.dart';
 
 final storageLock = Lock();
 
+String effectiveStorageEnvironment(
+  String configuredEnvironment, {
+  required bool isDebug,
+}) {
+  return isDebug ? configuredEnvironment : '.env';
+}
+
 String storageKeyForEnvironment(String key, String environment) {
   if (environment == '.env') return key;
   return '${Uri.encodeComponent(environment)}:$key';
@@ -49,21 +56,24 @@ class SecureStorage {
   }
 
   static Future<bool> containsKey(String key) async {
+    final scopedKey = _scopedKey(key);
     return await storageLock.synchronized(() async {
-      return await storage.containsKey(key: _scopedKey(key));
+      return await storage.containsKey(key: scopedKey);
     });
   }
 
   static Future<void> write(String key, String value) async {
+    final scopedKey = _scopedKey(key);
     return await storageLock.synchronized(() async {
-      return await storage.write(key: _scopedKey(key), value: value);
+      return await storage.write(key: scopedKey, value: value);
     });
   }
 
   static Future<String?> read(String key) async {
+    final scopedKey = _scopedKey(key);
     return await storageLock.synchronized(() async {
       try {
-        return await storage.read(key: _scopedKey(key));
+        return await storage.read(key: scopedKey);
       } catch (e) {
         StudyULogger.error("Error reading key $key from secure storage: $e");
         if (e is PlatformException && e.code == 'BadPaddingException') {
@@ -83,8 +93,9 @@ class SecureStorage {
   }
 
   static Future<void> delete(String key) async {
+    final scopedKey = _scopedKey(key);
     return await storageLock.synchronized(() async {
-      return await storage.delete(key: _scopedKey(key));
+      return await storage.delete(key: scopedKey);
     });
   }
 

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -7,13 +7,14 @@ import 'package:synchronized/synchronized.dart';
 
 final storageLock = Lock();
 
-String supabaseSessionStorageKey(String supabaseUrl) {
+String supabaseSessionStorageKey(String? supabaseUrl) {
+  if (supabaseUrl == null) return supabasePersistSessionKey;
   final authority = Uri.parse(supabaseUrl).authority;
   return '$supabasePersistSessionKey-${Uri.encodeComponent(authority)}';
 }
 
 class SupabaseStorage extends LocalStorage {
-  SupabaseStorage(String supabaseUrl)
+  SupabaseStorage([String? supabaseUrl])
     : _persistSessionKey = supabaseSessionStorageKey(supabaseUrl);
 
   final String _persistSessionKey;

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -7,15 +7,14 @@ import 'package:synchronized/synchronized.dart';
 
 final storageLock = Lock();
 
-String supabaseSessionStorageKey(String? supabaseUrl) {
-  if (supabaseUrl == null) return supabasePersistSessionKey;
-  final authority = Uri.parse(supabaseUrl).authority;
-  return '$supabasePersistSessionKey-${Uri.encodeComponent(authority)}';
+String supabaseSessionStorageKey(String? environment) {
+  if (environment == null) return supabasePersistSessionKey;
+  return '$supabasePersistSessionKey-${Uri.encodeComponent(environment)}';
 }
 
 class SupabaseStorage extends LocalStorage {
-  SupabaseStorage([String? supabaseUrl])
-    : _persistSessionKey = supabaseSessionStorageKey(supabaseUrl);
+  SupabaseStorage([String? environment])
+    : _persistSessionKey = supabaseSessionStorageKey(environment);
 
   final String _persistSessionKey;
 

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -7,60 +7,63 @@ import 'package:synchronized/synchronized.dart';
 
 final storageLock = Lock();
 
-String supabaseSessionStorageKey(String? environment) {
-  if (environment == null) return supabasePersistSessionKey;
-  return '$supabasePersistSessionKey-${Uri.encodeComponent(environment)}';
+String storageKeyForEnvironment(String key, String environment) {
+  if (environment == '.env') return key;
+  return '${Uri.encodeComponent(environment)}:$key';
 }
 
 class SupabaseStorage extends LocalStorage {
-  SupabaseStorage([String? environment])
-    : _persistSessionKey = supabaseSessionStorageKey(environment);
-
-  final String _persistSessionKey;
-
   @override
   Future<void> initialize() async {}
 
   @override
   Future<bool> hasAccessToken() async {
-    return await SecureStorage.containsKey(_persistSessionKey);
+    return await SecureStorage.containsKey(supabasePersistSessionKey);
   }
 
   @override
   Future<String?> accessToken() async {
-    return await SecureStorage.read(_persistSessionKey);
+    return await SecureStorage.read(supabasePersistSessionKey);
   }
 
   @override
   Future<void> persistSession(String persistSessionString) async {
-    return await SecureStorage.write(_persistSessionKey, persistSessionString);
+    return await SecureStorage.write(
+      supabasePersistSessionKey,
+      persistSessionString,
+    );
   }
 
   @override
   Future<void> removePersistedSession() async {
-    return await SecureStorage.delete(_persistSessionKey);
+    return await SecureStorage.delete(supabasePersistSessionKey);
   }
 }
 
 class SecureStorage {
   static const storage = FlutterSecureStorage();
+  static String environment = '.env';
+
+  static String _scopedKey(String key) {
+    return storageKeyForEnvironment(key, environment);
+  }
 
   static Future<bool> containsKey(String key) async {
     return await storageLock.synchronized(() async {
-      return await storage.containsKey(key: key);
+      return await storage.containsKey(key: _scopedKey(key));
     });
   }
 
   static Future<void> write(String key, String value) async {
     return await storageLock.synchronized(() async {
-      return await storage.write(key: key, value: value);
+      return await storage.write(key: _scopedKey(key), value: value);
     });
   }
 
   static Future<String?> read(String key) async {
     return await storageLock.synchronized(() async {
       try {
-        return await storage.read(key: key);
+        return await storage.read(key: _scopedKey(key));
       } catch (e) {
         StudyULogger.error("Error reading key $key from secure storage: $e");
         if (e is PlatformException && e.code == 'BadPaddingException') {
@@ -81,7 +84,7 @@ class SecureStorage {
 
   static Future<void> delete(String key) async {
     return await storageLock.synchronized(() async {
-      return await storage.delete(key: key);
+      return await storage.delete(key: _scopedKey(key));
     });
   }
 

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -7,31 +7,38 @@ import 'package:synchronized/synchronized.dart';
 
 final storageLock = Lock();
 
+String supabaseSessionStorageKey(String supabaseUrl) {
+  final authority = Uri.parse(supabaseUrl).authority;
+  return '$supabasePersistSessionKey-${Uri.encodeComponent(authority)}';
+}
+
 class SupabaseStorage extends LocalStorage {
+  SupabaseStorage(String supabaseUrl)
+    : _persistSessionKey = supabaseSessionStorageKey(supabaseUrl);
+
+  final String _persistSessionKey;
+
   @override
   Future<void> initialize() async {}
 
   @override
   Future<bool> hasAccessToken() async {
-    return await SecureStorage.containsKey(supabasePersistSessionKey);
+    return await SecureStorage.containsKey(_persistSessionKey);
   }
 
   @override
   Future<String?> accessToken() async {
-    return await SecureStorage.read(supabasePersistSessionKey);
+    return await SecureStorage.read(_persistSessionKey);
   }
 
   @override
   Future<void> persistSession(String persistSessionString) async {
-    return await SecureStorage.write(
-      supabasePersistSessionKey,
-      persistSessionString,
-    );
+    return await SecureStorage.write(_persistSessionKey, persistSessionString);
   }
 
   @override
   Future<void> removePersistedSession() async {
-    return await SecureStorage.delete(supabasePersistSessionKey);
+    return await SecureStorage.delete(_persistSessionKey);
   }
 }
 

--- a/flutter_common/test/src/utils/storage_test.dart
+++ b/flutter_common/test/src/utils/storage_test.dart
@@ -1,16 +1,73 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_flutter_common/src/utils/storage.dart';
 
 void main() {
-  test('scopes storage outside the production environment', () {
-    expect(storageKeyForEnvironment('user_email', '.env'), 'user_email');
-    expect(
-      storageKeyForEnvironment('user_email', '.env.dev'),
-      '.env.dev:user_email',
-    );
-    expect(
-      storageKeyForEnvironment('user_email', '.env.local'),
-      '.env.local:user_email',
-    );
+  late String originalEnvironment;
+
+  setUp(() {
+    originalEnvironment = SecureStorage.environment;
+    FlutterSecureStorage.setMockInitialValues({});
   });
+
+  tearDown(() {
+    SecureStorage.environment = originalEnvironment;
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('scopes storage only for non-production debug environments', () {
+    expect(effectiveStorageEnvironment('.env.dev', isDebug: true), '.env.dev');
+    expect(
+      effectiveStorageEnvironment('.env.local', isDebug: true),
+      '.env.local',
+    );
+    expect(effectiveStorageEnvironment('.env', isDebug: true), '.env');
+    expect(effectiveStorageEnvironment('.env.dev', isDebug: false), '.env');
+  });
+
+  test(
+    'isolates direct secure storage values between debug environments',
+    () async {
+      SecureStorage.environment = '.env.dev';
+      await SecureStorage.write('user_email', 'dev@example.com');
+
+      SecureStorage.environment = '.env.local';
+      expect(await SecureStorage.read('user_email'), isNull);
+      await SecureStorage.write('user_email', 'local@example.com');
+
+      SecureStorage.environment = '.env';
+      expect(await SecureStorage.read('user_email'), isNull);
+      await SecureStorage.write('user_email', 'prod@example.com');
+
+      SecureStorage.environment = '.env.dev';
+      expect(await SecureStorage.read('user_email'), 'dev@example.com');
+
+      expect(
+        await SecureStorage.storage.readAll(),
+        containsPair('.env.dev:user_email', 'dev@example.com'),
+      );
+    },
+  );
+
+  test(
+    'isolates persisted Supabase sessions between debug environments',
+    () async {
+      final storage = SupabaseStorage();
+
+      SecureStorage.environment = '.env.dev';
+      await storage.persistSession('dev-session');
+
+      SecureStorage.environment = '.env.local';
+      expect(await storage.accessToken(), isNull);
+      await storage.persistSession('local-session');
+
+      SecureStorage.environment = '.env.dev';
+      expect(await storage.accessToken(), 'dev-session');
+      await storage.removePersistedSession();
+      expect(await storage.accessToken(), isNull);
+
+      SecureStorage.environment = '.env.local';
+      expect(await storage.accessToken(), 'local-session');
+    },
+  );
 }

--- a/flutter_common/test/src/utils/storage_test.dart
+++ b/flutter_common/test/src/utils/storage_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_flutter_common/src/utils/storage.dart';
+
+void main() {
+  test('Supabase session storage is isolated by backend origin', () {
+    final developmentKey = supabaseSessionStorageKey(
+      'https://development.supabase.co',
+    );
+    final productionKey = supabaseSessionStorageKey(
+      'https://production.supabase.co',
+    );
+    final localKey = supabaseSessionStorageKey('http://localhost:54321');
+
+    expect(developmentKey, isNot(productionKey));
+    expect(localKey, contains('localhost%3A54321'));
+  });
+}

--- a/flutter_common/test/src/utils/storage_test.dart
+++ b/flutter_common/test/src/utils/storage_test.dart
@@ -13,5 +13,6 @@ void main() {
 
     expect(developmentKey, isNot(productionKey));
     expect(localKey, contains('localhost%3A54321'));
+    expect(supabaseSessionStorageKey(null), 'SUPABASE_PERSIST_SESSION_KEY');
   });
 }

--- a/flutter_common/test/src/utils/storage_test.dart
+++ b/flutter_common/test/src/utils/storage_test.dart
@@ -2,17 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_flutter_common/src/utils/storage.dart';
 
 void main() {
-  test('Supabase session storage is isolated by backend origin', () {
-    final developmentKey = supabaseSessionStorageKey(
-      'https://development.supabase.co',
-    );
-    final productionKey = supabaseSessionStorageKey(
-      'https://production.supabase.co',
-    );
-    final localKey = supabaseSessionStorageKey('http://localhost:54321');
+  test('Supabase session storage is isolated by debug environment', () {
+    final developmentKey = supabaseSessionStorageKey('.env.dev');
+    final productionKey = supabaseSessionStorageKey('.env');
 
     expect(developmentKey, isNot(productionKey));
-    expect(localKey, contains('localhost%3A54321'));
     expect(supabaseSessionStorageKey(null), 'SUPABASE_PERSIST_SESSION_KEY');
   });
 }

--- a/flutter_common/test/src/utils/storage_test.dart
+++ b/flutter_common/test/src/utils/storage_test.dart
@@ -2,11 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_flutter_common/src/utils/storage.dart';
 
 void main() {
-  test('Supabase session storage is isolated by debug environment', () {
-    final developmentKey = supabaseSessionStorageKey('.env.dev');
-    final productionKey = supabaseSessionStorageKey('.env');
-
-    expect(developmentKey, isNot(productionKey));
-    expect(supabaseSessionStorageKey(null), 'SUPABASE_PERSIST_SESSION_KEY');
+  test('scopes storage outside the production environment', () {
+    expect(storageKeyForEnvironment('user_email', '.env'), 'user_email');
+    expect(
+      storageKeyForEnvironment('user_email', '.env.dev'),
+      '.env.dev:user_email',
+    );
+    expect(
+      storageKeyForEnvironment('user_email', '.env.local'),
+      '.env.local:user_email',
+    );
   });
 }


### PR DESCRIPTION
## Description
Switching `STUDYU_ENV` while reusing fixed localhost ports caused Flutter web to restore Supabase sessions and participant-local data from the previous environment. The stale credentials produced invalid JWT and refresh-token failures until browser storage was cleared manually.

This change namespaces all `SecureStorage` keys by `STUDYU_ENV` in debug builds. `.env.dev` and `.env.local` therefore keep separate sessions, participant credentials, selected subjects, caches, and onboarding state. Debug `.env` and all profile/release builds retain the existing unscoped keys, so deployed participants and Designer users keep their current storage behavior. Supabase fallback URLs within one environment continue sharing the same namespace.

The storage namespace is selected before environment loading, and each operation resolves its key before waiting for the storage lock.

## Testing Steps
1. Run the app on port 8080 with `--dart-define=STUDYU_ENV=.env.dev` and create or restore participant state.
2. Restart it on the same port with `.env.local`; verify it does not restore the `.env.dev` session or participant data.
3. Switch back to `.env.dev`; verify its previous debug state is restored.
4. Repeat the environment switch for Designer on port 8081 and verify no stale refresh-token errors occur.
5. Run `cd flutter_common && rtk fvm flutter test`.
6. Run `scripts/pre-commit-check` from the repository root.

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analyzers pass via `scripts/pre-commit-check`
- [x] No visual changes
- [ ] Manual app and Designer environment-switch flow verified
