### PR TITLE
fix(app): prevent invite dialog navigation race

### DIFF
--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -250,21 +250,25 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
         icon: const Icon(Icons.arrow_forward),
         label: Text(AppLocalizations.of(context)!.next),
         onPressed: () async {
+          final inviteCode = _controller.text;
           Map<String, dynamic>? studyResult;
           try {
             studyResult = await Supabase.instance.client
                 .rpc(
                   'get_study_record_from_invite',
-                  params: {'invite_code': _controller.text},
+                  params: {'invite_code': inviteCode},
                 )
                 .single();
           } on PostgrestException catch (error) {
             print(error.message);
+            if (!mounted) return;
             setState(() {
               _errorMessage = error.message;
             });
+            return;
           }
-          if (studyResult == null || studyResult['id'] == null) {
+          if (!mounted) return;
+          if (studyResult['id'] == null) {
             setState(() {
               _errorMessage = AppLocalizations.of(context)!.invalid_invite_code;
             });
@@ -295,7 +299,7 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
             final inviteResult = await Supabase.instance.client
                 .from('study_invite')
                 .select('preselected_intervention_ids')
-                .eq('code', _controller.text)
+                .eq('code', inviteCode)
                 .maybeSingle();
             if (!context.mounted) return;
 
@@ -306,7 +310,7 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
                 preselectedInterventionIds == null
                 ? null
                 : List<String>.from(preselectedInterventionIds as List);
-            appState.inviteCode = _controller.text;
+            appState.inviteCode = inviteCode;
             appState.selectedStudy = study;
             Navigator.pushReplacementNamed(context, Routes.studyOverview);
           }

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -312,6 +312,7 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
                 : List<String>.from(preselectedInterventionIds as List);
             appState.inviteCode = inviteCode;
             appState.selectedStudy = study;
+            // Replace (not push) so accepting an invite can't be undone via back button.
             Navigator.pushReplacementNamed(context, Routes.studyOverview);
           }
         },

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -292,16 +292,15 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
               return;
             }
 
-            if (!context.mounted) return;
-            Navigator.pop(context);
-
-            // Get preselected_intervention_ids from study_invite table
+            // Get preselected_intervention_ids before closing the dialog so its
+            // context remains mounted while the request is in flight.
             final inviteResult = await Supabase.instance.client
                 .from('study_invite')
                 .select('preselected_intervention_ids')
                 .eq('code', _controller.text)
                 .maybeSingle();
             if (!context.mounted) return;
+            Navigator.pop(context);
             if (inviteResult != null &&
                 inviteResult.containsKey('preselected_intervention_ids') &&
                 inviteResult['preselected_intervention_ids'] != null) {

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -292,34 +292,23 @@ class _InviteCodeDialogState extends State<InviteCodeDialog> {
               return;
             }
 
-            // Get preselected_intervention_ids before closing the dialog so its
-            // context remains mounted while the request is in flight.
             final inviteResult = await Supabase.instance.client
                 .from('study_invite')
                 .select('preselected_intervention_ids')
                 .eq('code', _controller.text)
                 .maybeSingle();
             if (!context.mounted) return;
-            Navigator.pop(context);
-            if (inviteResult != null &&
-                inviteResult.containsKey('preselected_intervention_ids') &&
-                inviteResult['preselected_intervention_ids'] != null) {
-              final preselectedIds = List<String>.from(
-                inviteResult['preselected_intervention_ids'] as List,
-              );
-              await navigateToStudyOverview(
-                context,
-                study,
-                inviteCode: _controller.text,
-                preselectedIds: preselectedIds,
-              );
-            } else {
-              await navigateToStudyOverview(
-                context,
-                study,
-                inviteCode: _controller.text,
-              );
-            }
+
+            final preselectedInterventionIds =
+                inviteResult?['preselected_intervention_ids'];
+            final appState = context.read<AppState>();
+            appState.preselectedInterventionIds =
+                preselectedInterventionIds == null
+                ? null
+                : List<String>.from(preselectedInterventionIds as List);
+            appState.inviteCode = _controller.text;
+            appState.selectedStudy = study;
+            Navigator.pushReplacementNamed(context, Routes.studyOverview);
           }
         },
       ),

--- a/designer_v2/pubspec.yaml
+++ b/designer_v2/pubspec.yaml
@@ -1,6 +1,7 @@
 name: studyu_designer_v2
 version: 1.15.3
-description: Implement digital N-of-1 studies seamlessly with the StudyU Health Designer
+description: >-
+  Implement digital N-of-1 studies seamlessly with the StudyU Health Designer
 publish_to: none
 homepage: https://studyu.health
 repository: https://github.com/hpi-studyu/studyu
@@ -47,7 +48,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.10.3
-  custom_lint:
+  custom_lint: 0.8.1
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   flutter_test:
@@ -58,7 +59,7 @@ dev_dependencies:
   lint: ^2.8.0
   patrol_finders: ^2.9.0
   riverpod_generator: ^3.0.3
-  riverpod_lint:
+  riverpod_lint: 3.0.3
   test: ^1.25.15 # integration_test
 
 flutter:


### PR DESCRIPTION
## Summary
- fetch all invite metadata before leaving the invite dialog
- guard asynchronous continuations when the dialog has been dismissed
- snapshot the submitted invite code so both lookups and AppState use the same value
- replace the invite dialog directly with the study overview instead of popping and navigating with the dialog context
- pin compatible `custom_lint` and `riverpod_lint` versions so fresh CI environments do not resolve the incompatible Riverpod 3.1 native plugin

## Why
The dialog was popped before the second Supabase request. On slower responses, Flutter disposed the dialog while awaiting the request, causing the subsequent `context.mounted` guard to return before navigation. Using `pushReplacementNamed` removes the dialog and opens the overview in one navigation operation. Mounted guards also protect dismissal during the first lookup, while snapshotting prevents edits during the requests from mixing two invite codes.

The CI analyzer plugin manager independently resolved the unconstrained `riverpod_lint` dependency to 3.1.4, while this main branch still uses the custom-lint-based 3.0 API. Pinning the existing lockfile versions makes analysis deterministic.

## Verification
- `fvm flutter analyze`
- `cd app && fvm flutter test test/widget_test.dart`
- parent-orchestrated three-round fresh-context review loop
- CI static analysis, tests, linter, and MegaLinter pass