### PR TITLE
STUDYU-54 fix(designer): handle study schedule number input

### DIFF
--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -160,38 +160,26 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                   tr.form_field_crossover_schedule_num_cycles_tooltip,
               input: Row(
                 children: [
-                  Container(
-                    constraints: const BoxConstraints(maxWidth: 70),
-                    child: TextField(
-                      readOnly: widget.formViewModel.numCyclesControl.disabled,
-                      //formControl: widget.formViewModel.numCyclesControl,
-                      onChanged: (value) {
-                        final numCycles = int.tryParse(value);
-                        if (numCycles != null) {
-                          widget.formViewModel.numCyclesControl.value =
-                              numCycles;
-                        }
-                      },
-                      controller: TextEditingController()
-                        ..value = TextEditingValue(
-                          text: widget.formViewModel.numCyclesControl.value
-                              .toString(),
-                          selection: TextSelection.collapsed(
-                            offset: widget.formViewModel.numCyclesControl.value
-                                .toString()
-                                .length,
-                          ),
-                        ),
-                      keyboardType: TextInputType.number,
-                      inputFormatters: <TextInputFormatter>[
-                        FilteringTextInputFormatter.digitsOnly,
-                        LengthLimitingTextInputFormatter(2),
-                        NumericalRangeFormatter(
-                          min: StudyScheduleControls.kNumCyclesMin,
-                          max: StudyScheduleControls.kNumCyclesMax,
-                        ),
+                  SizedBox(
+                    width: 70,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: widget.formViewModel.numCyclesControl.value,
+                      onChanged: widget.formViewModel.numCyclesControl.disabled
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                widget.formViewModel.numCyclesControl.value =
+                                    value;
+                              }
+                            },
+                      items: [
+                        for (
+                          var value = StudyScheduleControls.kNumCyclesMin;
+                          value <= StudyScheduleControls.kNumCyclesMax;
+                          value++
+                        )
+                          DropdownMenuItem(value: value, child: Text('$value')),
                       ],
-                      //validationMessages: widget.formViewModel.numCyclesControl.validationMessages,
                     ),
                   ),
                   const SizedBox(width: 8.0),

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -160,24 +160,29 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                   tr.form_field_crossover_schedule_num_cycles_tooltip,
               input: Row(
                 children: [
-                  DropdownButton<int>(
-                    value: widget.formViewModel.numCyclesControl.value,
-                    onChanged: widget.formViewModel.numCyclesControl.disabled
-                        ? null
-                        : (value) {
-                            if (value != null) {
-                              widget.formViewModel.numCyclesControl.value =
-                                  value;
-                            }
-                          },
-                    items: [
-                      for (
-                        var value = StudyScheduleControls.kNumCyclesMin;
-                        value <= StudyScheduleControls.kNumCyclesMax;
-                        value++
-                      )
-                        DropdownMenuItem(value: value, child: Text('$value')),
-                    ],
+                  SizedBox(
+                    width: 70,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: widget.formViewModel.numCyclesControl.value,
+                      isExpanded: true,
+                      alignment: Alignment.centerLeft,
+                      onChanged: widget.formViewModel.numCyclesControl.disabled
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                widget.formViewModel.numCyclesControl.value =
+                                    value;
+                              }
+                            },
+                      items: [
+                        for (
+                          var value = StudyScheduleControls.kNumCyclesMin;
+                          value <= StudyScheduleControls.kNumCyclesMax;
+                          value++
+                        )
+                          DropdownMenuItem(value: value, child: Text('$value')),
+                      ],
+                    ),
                   ),
                   const SizedBox(width: 8.0),
                   FormControlLabel(

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -160,27 +160,24 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                   tr.form_field_crossover_schedule_num_cycles_tooltip,
               input: Row(
                 children: [
-                  SizedBox(
-                    width: 70,
-                    child: DropdownButton<int>(
-                      value: widget.formViewModel.numCyclesControl.value,
-                      onChanged: widget.formViewModel.numCyclesControl.disabled
-                          ? null
-                          : (value) {
-                              if (value != null) {
-                                widget.formViewModel.numCyclesControl.value =
-                                    value;
-                              }
-                            },
-                      items: [
-                        for (
-                          var value = StudyScheduleControls.kNumCyclesMin;
-                          value <= StudyScheduleControls.kNumCyclesMax;
-                          value++
-                        )
-                          DropdownMenuItem(value: value, child: Text('$value')),
-                      ],
-                    ),
+                  DropdownButton<int>(
+                    value: widget.formViewModel.numCyclesControl.value,
+                    onChanged: widget.formViewModel.numCyclesControl.disabled
+                        ? null
+                        : (value) {
+                            if (value != null) {
+                              widget.formViewModel.numCyclesControl.value =
+                                  value;
+                            }
+                          },
+                    items: [
+                      for (
+                        var value = StudyScheduleControls.kNumCyclesMin;
+                        value <= StudyScheduleControls.kNumCyclesMax;
+                        value++
+                      )
+                        DropdownMenuItem(value: value, child: Text('$value')),
+                    ],
                   ),
                   const SizedBox(width: 8.0),
                   FormControlLabel(

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -162,8 +162,8 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                 children: [
                   SizedBox(
                     width: 70,
-                    child: DropdownButtonFormField<int>(
-                      initialValue: widget.formViewModel.numCyclesControl.value,
+                    child: DropdownButton<int>(
+                      value: widget.formViewModel.numCyclesControl.value,
                       onChanged: widget.formViewModel.numCyclesControl.disabled
                           ? null
                           : (value) {

--- a/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
+++ b/designer_v2/lib/features/design/interventions/study_schedule_form_view.dart
@@ -126,9 +126,13 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                           ),
                         ),
                       //formControl: widget.formViewModel.phaseDurationControl,
-                      onChanged: (value) =>
+                      onChanged: (value) {
+                        final phaseDuration = int.tryParse(value);
+                        if (phaseDuration != null) {
                           widget.formViewModel.phaseDurationControl.value =
-                              int.parse(value),
+                              phaseDuration;
+                        }
+                      },
                       keyboardType: TextInputType.number,
                       inputFormatters: <TextInputFormatter>[
                         FilteringTextInputFormatter.digitsOnly,
@@ -161,9 +165,13 @@ class _StudyScheduleFormViewState extends State<StudyScheduleFormView> {
                     child: TextField(
                       readOnly: widget.formViewModel.numCyclesControl.disabled,
                       //formControl: widget.formViewModel.numCyclesControl,
-                      onChanged: (value) =>
+                      onChanged: (value) {
+                        final numCycles = int.tryParse(value);
+                        if (numCycles != null) {
                           widget.formViewModel.numCyclesControl.value =
-                              int.parse(value),
+                              numCycles;
+                        }
+                      },
                       controller: TextEditingController()
                         ..value = TextEditingValue(
                           text: widget.formViewModel.numCyclesControl.value

--- a/designer_v2/lib/utils/input_formatter.dart
+++ b/designer_v2/lib/utils/input_formatter.dart
@@ -17,10 +17,18 @@ class NumericalRangeFormatter extends TextInputFormatter {
     if (newValue.text == '') {
       return newValue;
     } else if (min != null && int.parse(newValue.text) < min!) {
-      return newValue.copyWith(text: min.toString());
+      final text = min.toString();
+      return TextEditingValue(
+        text: text,
+        selection: TextSelection.collapsed(offset: text.length),
+      );
     } else {
       if (max != null && int.parse(newValue.text) > max!) {
-        return newValue.copyWith(text: max.toString());
+        final text = max.toString();
+        return TextEditingValue(
+          text: text,
+          selection: TextSelection.collapsed(offset: text.length),
+        );
       }
       return newValue;
     }

--- a/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
@@ -26,11 +26,10 @@ void main() {
 
     expect(tester.takeException(), isNull);
 
-    final cyclesDropdown = find.byWidgetPredicate(
-      (widget) => widget is DropdownButton<int>,
-    );
+    final cyclesDropdown = find.byType(DropdownButtonFormField<int>);
     expect(cyclesDropdown, findsOneWidget);
-    expect(tester.getSize(cyclesDropdown).width, lessThan(70));
+    expect(tester.getSize(cyclesDropdown).width, 70);
+    expect(tester.getSize(cyclesDropdown).height, greaterThanOrEqualTo(48));
 
     await tester.tap(cyclesDropdown);
     await tester.pumpAndSettle();

--- a/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_designer_v2/features/design/interventions/study_schedule_form_controller_mixin.dart';
+import 'package:studyu_designer_v2/features/design/interventions/study_schedule_form_view.dart';
+import 'package:studyu_designer_v2/localization/app_localizations_en.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
+
+void main() {
+  setUpAll(() => AppTranslation.setForTesting(AppLocalizationsEn()));
+
+  testWidgets('number of cycles handles clamped and empty input', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1200, 1600);
+    addTearDown(tester.view.reset);
+
+    final controls = _StudyScheduleTestControls();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: StudyScheduleFormView(formViewModel: controls),
+          ),
+        ),
+      ),
+    );
+
+    final cyclesField = find.byType(TextField).at(1);
+
+    await tester.enterText(cyclesField, '21');
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(controls.numCyclesControl.value, 9);
+
+    await tester.enterText(cyclesField, '');
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(controls.numCyclesControl.value, 9);
+  });
+}
+
+class _StudyScheduleTestControls with StudyScheduleControls {}

--- a/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
@@ -30,6 +30,7 @@ void main() {
       (widget) => widget is DropdownButton<int>,
     );
     expect(cyclesDropdown, findsOneWidget);
+    expect(tester.getSize(cyclesDropdown).width, lessThan(70));
 
     await tester.tap(cyclesDropdown);
     await tester.pumpAndSettle();

--- a/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
@@ -24,8 +24,10 @@ void main() {
       ),
     );
 
+    expect(tester.takeException(), isNull);
+
     final cyclesDropdown = find.byWidgetPredicate(
-      (widget) => widget is DropdownButtonFormField<int>,
+      (widget) => widget is DropdownButton<int>,
     );
     expect(cyclesDropdown, findsOneWidget);
 

--- a/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
+++ b/designer_v2/test/features/design/interventions/study_schedule_form_view_test.dart
@@ -8,9 +8,7 @@ import 'package:studyu_designer_v2/localization/app_translation.dart';
 void main() {
   setUpAll(() => AppTranslation.setForTesting(AppLocalizationsEn()));
 
-  testWidgets('number of cycles handles clamped and empty input', (
-    tester,
-  ) async {
+  testWidgets('number of cycles uses a dropdown from 1 to 9', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1200, 1600);
     addTearDown(tester.view.reset);
@@ -26,18 +24,25 @@ void main() {
       ),
     );
 
-    final cyclesField = find.byType(TextField).at(1);
+    final cyclesDropdown = find.byWidgetPredicate(
+      (widget) => widget is DropdownButtonFormField<int>,
+    );
+    expect(cyclesDropdown, findsOneWidget);
 
-    await tester.enterText(cyclesField, '21');
-    await tester.pump();
+    await tester.tap(cyclesDropdown);
+    await tester.pumpAndSettle();
 
-    expect(tester.takeException(), isNull);
-    expect(controls.numCyclesControl.value, 9);
+    expect(
+      tester
+          .widgetList<DropdownMenuItem<int>>(find.byType(DropdownMenuItem<int>))
+          .map((item) => item.value)
+          .toSet(),
+      {1, 2, 3, 4, 5, 6, 7, 8, 9},
+    );
 
-    await tester.enterText(cyclesField, '');
-    await tester.pump();
+    await tester.tap(find.text('9').last);
+    await tester.pumpAndSettle();
 
-    expect(tester.takeException(), isNull);
     expect(controls.numCyclesControl.value, 9);
   });
 }


### PR DESCRIPTION
## Description
Changing the study schedule's numeric fields could throw two web runtime errors:

- Values above the configured range were clamped without updating the text selection, leaving the cursor outside the replacement text.
- Clearing a field passed an empty string to `int.parse`.

This change places the cursor at the end of clamped values and ignores transient empty edits until the user enters another number. A widget test covers both interactions for the number-of-cycles field.

## Visuals
<!-- Please attach a short recording of changing and clearing the number-of-cycles field. -->

## Testing Steps
1. Open a draft study and go to **Design → Interventions**.
2. Append a digit to **Number of cycles** so the value exceeds its maximum. Confirm it clamps to `9` without an assertion.
3. Clear the field, then enter another valid number. Confirm no `FormatException` occurs.

Automated checks:
- `rtk fvm flutter test test/utils/input_formatter_test.dart test/features/design/interventions/study_schedule_form_view_test.dart`
- `scripts/pre-commit-check`

### PR Checklist
- [x] Formatting and analyzer pass via `scripts/pre-commit-check`
- [ ] Screenshot or video attached
