### PR TITLE
fix(core): preserve empty eligibility choice semantics

### DIFF
--- a/core/lib/src/models/eligibility/eligibility_criterion.dart
+++ b/core/lib/src/models/eligibility/eligibility_criterion.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:studyu_core/src/models/expressions/expression.dart';
 import 'package:studyu_core/src/models/expressions/types/boolean_expression.dart';
+import 'package:studyu_core/src/models/expressions/types/choice_expression.dart';
 import 'package:studyu_core/src/models/questionnaire/questionnaire_state.dart';
 import 'package:uuid/uuid.dart';
 
@@ -22,8 +23,20 @@ class EligibilityCriterion {
       _$EligibilityCriterionFromJson(data);
   Map<String, dynamic> toJson() => _$EligibilityCriterionToJson(this);
 
-  bool isSatisfied(QuestionnaireState qs) => condition.evaluate(qs) == true;
-  bool isViolated(QuestionnaireState qs) => condition.evaluate(qs) == false;
+  bool? _evaluate(QuestionnaireState qs) {
+    final condition = this.condition;
+    // ponytail: Legacy screeners encode "none apply" as an empty choice set;
+    // remove this when they are migrated to NotExpression.
+    if (condition is ChoiceExpression &&
+        condition.choices.isEmpty &&
+        qs.hasAnswer<List<String>>(condition.target!)) {
+      return qs.getAnswer<List<String>>(condition.target!).isEmpty;
+    }
+    return condition.evaluate(qs);
+  }
+
+  bool isSatisfied(QuestionnaireState qs) => _evaluate(qs) == true;
+  bool isViolated(QuestionnaireState qs) => _evaluate(qs) == false;
 
   // does not compare id
   @override

--- a/core/test/expressions/choice_expression_test.dart
+++ b/core/test/expressions/choice_expression_test.dart
@@ -1,0 +1,21 @@
+import 'package:studyu_core/core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('empty multi-choice answer satisfies the none-selected criterion', () {
+    final question = ChoiceQuestion.withId()..id = 'red_flags';
+    final state = QuestionnaireState()
+      ..answers[question.id] = Answer<List<String>>.forQuestion(
+        question,
+        <String>[],
+      );
+    final criterion = EligibilityCriterion.withId()
+      ..condition = (ChoiceExpression()
+        ..target = question.id
+        ..choices = <dynamic>{});
+
+    expect(criterion.condition.evaluate(state), isFalse);
+    expect(criterion.isSatisfied(state), isTrue);
+    expect(criterion.isViolated(state), isFalse);
+  });
+}


### PR DESCRIPTION
## Description
The nutrition branch made an empty choice answer evaluate to `false`, which is correct for normal choice expressions but broke legacy eligibility screeners that encode the qualifying "none apply" response as an empty choice set.

This change keeps the generic `ChoiceExpression` behavior unchanged and applies the legacy compatibility rule only inside `EligibilityCriterion`. Empty answers satisfy an empty eligibility choice set, while ordinary choice conditions continue to treat an empty answer as unmet.

A focused regression test verifies both sides of that behavior.

## Testing Steps
1. Run `cd core && rtk fvm dart test test/expressions/choice_expression_test.dart`.
2. Open a study with a multi-select eligibility question whose qualifying answer is selecting no listed warning signs.
3. Confirm the participant remains eligible after submitting an empty selection.

### PR Checklist
- [x] `scripts/pre-commit-check` passes (format, generation, and analyzer)
