### PR TITLE
fix(app): update browser title during onboarding

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -9,6 +9,21 @@ import 'package:studyu_app/theme.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
+String browserTitleForPath(String path, AppLocalizations l10n) =>
+    switch (path) {
+      '/${RouteNames.welcome}' ||
+      '/${RouteNames.onboarding}' => l10n.onboarding_page0_title,
+      '/${RouteNames.terms}' => l10n.terms,
+      '/${RouteNames.studySelection}' => l10n.study_selection,
+      '/${RouteNames.studyOverview}' => l10n.study_overview_title,
+      '/${RouteNames.eligibilityCheck}' => l10n.eligibility_questionnaire_title,
+      '/${RouteNames.interventionSelection}' =>
+        l10n.intervention_selection_title,
+      '/${RouteNames.journey}' => l10n.your_journey,
+      '/${RouteNames.consent}' => l10n.consent,
+      _ => 'StudyU',
+    };
+
 class MyApp extends StatefulWidget {
   const MyApp(
     this.queryParameters,
@@ -48,27 +63,33 @@ class _MyAppState extends State<MyApp> {
       ],
       child: Consumer<AppLanguage>(
         builder: (context, model, child) {
-          return MaterialApp.router(
-            title: 'StudyU',
-            theme: theme,
-            routerConfig: _router,
-            localeListResolutionCallback: (locales, supportedLocales) {
-              // print('device locales=$locales supported locales=$supportedLocales');
-              final supportedLanguageCodes = supportedLocales.map(
-                (e) => e.languageCode,
-              );
-              if (locales != null) {
-                for (final locale in locales) {
-                  if (supportedLanguageCodes.contains(locale.languageCode)) {
-                    return locale;
+          return ListenableBuilder(
+            listenable: _router.routeInformationProvider,
+            builder: (context, child) => MaterialApp.router(
+              onGenerateTitle: (context) => browserTitleForPath(
+                _router.routeInformationProvider.value.uri.path,
+                AppLocalizations.of(context)!,
+              ),
+              theme: theme,
+              routerConfig: _router,
+              localeListResolutionCallback: (locales, supportedLocales) {
+                // print('device locales=$locales supported locales=$supportedLocales');
+                final supportedLanguageCodes = supportedLocales.map(
+                  (e) => e.languageCode,
+                );
+                if (locales != null) {
+                  for (final locale in locales) {
+                    if (supportedLanguageCodes.contains(locale.languageCode)) {
+                      return locale;
+                    }
                   }
                 }
-              }
-              return const Locale('en');
-            },
-            locale: model.appLocal,
-            supportedLocales: AppLocalizations.supportedLocales,
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
+                return const Locale('en');
+              },
+              locale: model.appLocal,
+              supportedLocales: AppLocalizations.supportedLocales,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+            ),
           );
         },
       ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -6,11 +6,14 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:studyu_app/app.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/l10n/app_localizations_en.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/about.dart';
 import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
@@ -54,6 +57,42 @@ Widget setup(Widget child) {
 }
 
 void main() {
+  test('uses the current onboarding route as the browser title', () {
+    final l10n = AppLocalizationsEn();
+
+    expect(browserTitleForPath('/terms', l10n), l10n.terms);
+    expect(browserTitleForPath('/consent', l10n), l10n.consent);
+    expect(
+      browserTitleForPath('/eligibilityCheck', l10n),
+      l10n.eligibility_questionnaire_title,
+    );
+  });
+
+  testWidgets('updates the browser title after onboarding navigation', (
+    tester,
+  ) async {
+    final titles = <String>[];
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'SystemChrome.setApplicationSwitcherDescription') {
+        titles.add((call.arguments as Map<String, dynamic>)['label'] as String);
+      }
+      return null;
+    });
+    addTearDown(
+      () => messenger.setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+
+    await tester.pumpWidget(const MyApp({}, null, initialRoute: '/welcome'));
+    await tester.pumpAndSettle();
+    expect(titles.last, 'Welcome to StudyU');
+
+    GoRouter.of(tester.element(find.byType(Navigator).last)).go('/terms');
+    await tester.pumpAndSettle();
+    expect(titles.last, 'Terms of Use');
+  });
+
   testWidgets('Counter increments smoke test', (tester) async {
     await tester.pumpWidget(setup(const WelcomeScreen()));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Description
Participant onboarding routes kept the previous browser title instead of reflecting the current step.

This change rebuilds the app title when GoRouter's location changes and uses the existing localized labels for Welcome, Terms, Study Selection, Overview, Eligibility Questionnaire, Interventions, Journey, and Consent. Other routes retain the `StudyU` fallback title.

Tests cover the route-to-title mapping and verify that the platform/browser title changes after navigation from Welcome to Terms.

## Visuals
<!-- Attach a screenshot or recording showing the browser tab title changing during onboarding. -->

## Testing Steps
1. Run `cd app && rtk fvm flutter test test/widget_test.dart`.
2. Start the participant web app.
3. Navigate from Welcome through the onboarding flow.
4. Verify the browser title follows the current step, including Terms, Questionnaire, and Consent.

### PR Checklist
- [x] `scripts/pre-commit-check` passes (format and analyzer)
- [ ] Screenshot or video attached
