### PR TITLE
fix(app): update browser url during onboarding

### DIFF
--- a/app/lib/app_router.dart
+++ b/app/lib/app_router.dart
@@ -63,6 +63,10 @@ GoRouter createAppRouter({
   String initialLocation = '/${RouteNames.loading}',
   GlobalKey<NavigatorState>? navigatorKey,
 }) {
+  // ponytail: Reflect the existing push-based navigation on web; use
+  // declarative routes instead if direct deep-linking becomes required.
+  GoRouter.optionURLReflectsImperativeAPIs = true;
+
   return GoRouter(
     navigatorKey: navigatorKey,
     initialLocation: initialLocation,

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester
@@ -6,6 +8,7 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -118,6 +121,52 @@ void main() {
     final onboarding = find.byKey(const ValueKey('onboarding_test_screen'));
     expect(onboarding, findsOneWidget);
     expect(GoRouter.of(tester.element(onboarding)).canPop(), isFalse);
+  });
+
+  testWidgets('pushed onboarding route updates the browser URL', (
+    tester,
+  ) async {
+    final navigationCalls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.navigation, (call) async {
+          navigationCalls.add(call);
+          return null;
+        });
+
+    GoRouter.optionURLReflectsImperativeAPIs = false;
+    final router = createAppRouter(
+      queryParameters: const {},
+      initialLocation: '/${RouteNames.welcome}',
+    );
+    addTearDown(() {
+      router.dispose();
+      GoRouter.optionURLReflectsImperativeAPIs = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.navigation, null);
+    });
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AppState(),
+        child: MaterialApp.router(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    navigationCalls.clear();
+
+    unawaited(router.push('/${RouteNames.about}'));
+    await tester.pumpAndSettle();
+
+    final update = navigationCalls.lastWhere(
+      (call) => call.method == 'routeInformationUpdated',
+    );
+    final arguments = update.arguments! as Map<Object?, Object?>;
+    expect(arguments['uri'] ?? arguments['location'], '/${RouteNames.about}');
   });
 
   testWidgets('terms back falls back to welcome without previous screen', (


### PR DESCRIPTION
## Description
Onboarding screens use GoRouter's imperative `push` API so participants can navigate back through the flow. By default, go_router excludes pushed routes from the browser URL, leaving paths such as `/welcome` visible after the app has advanced to About, Terms, Eligibility, or Consent.

This change enables browser URL reflection for imperative routes when the app router is created. It preserves the existing navigation stack while making the address bar follow the visible onboarding screen.

A widget test intercepts Flutter's navigation channel and verifies that pushing an onboarding route reports the new path to the browser.

## Visuals
<!-- Attach a screenshot or recording showing the browser URL changing during onboarding. -->

## Testing Steps
1. Run `cd app && rtk fvm flutter test test/widget_test.dart --plain-name "pushed onboarding route updates the browser URL"`.
2. Start the participant web app.
3. Navigate from Welcome through the onboarding flow.
4. Verify the URL changes for pushed screens such as About, Terms, Study Overview, Eligibility, Journey, and Consent.
5. Use the browser or in-app back action and verify the existing onboarding history still works.

### PR Checklist
- [x] `scripts/pre-commit-check` passes (format and analyzer)
- [ ] Screenshot or video attached
