### PR TITLE
[STUDYU-77] feat(app): add ui mcp automation

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,9 +5,13 @@ on:
     paths:
       - ".github/workflows/e2e_tests.yml"
       - ".github/workflows/init-workspace/action.yml"
+      - 'app/**'
       - 'designer_v2/**'
       - 'core/**'
       - 'flutter_common/**'
+      - 'tools/studyu_mcp/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
   workflow_dispatch:
 
 env:
@@ -63,10 +67,19 @@ jobs:
           chromedriver --port=4444 &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 
-      - name: Run Flutter E2E tests
+      - name: Run Designer E2E tests
         working-directory: ./designer_v2
         run: |
           flutter drive --driver=test_driver/integration_driver.dart \
             --target=integration_test/app_test.dart -d web-server \
+            --web-browser-flag="--disable-web-security" \
+            --dart-define="STUDYU_ENV=.env.local"
+
+      - name: Run App onboarding E2E test
+        working-directory: ./app
+        run: |
+          flutter drive --driver=test_driver/integration_driver.dart \
+            --target=integration_test/onboarding_study_list_test.dart \
+            -d web-server \
             --web-browser-flag="--disable-web-security" \
             --dart-define="STUDYU_ENV=.env.local"

--- a/app/integration_test/onboarding_study_list_test.dart
+++ b/app/integration_test/onboarding_study_list_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:studyu_app/main.dart' as app_main;
+import 'package:studyu_app/studyu_driver_state.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(SecureStorage.deleteAll);
+
+  testWidgets('onboarding reaches the study list', (tester) async {
+    final staleStudies = [StudyFixtures.invalidBrokenEligibilityRef()];
+    StudyUDriverState.visibleStudies = staleStudies;
+
+    await app_main.main();
+
+    final flow = StudyUAppUiFlow(
+      waitForKey: (key, {required timeout}) =>
+          tester.waitForValueKey(key, timeout: timeout),
+      tapKey: tester.tapValueKey,
+    );
+
+    await flow.completeOnboardingToStudyList();
+
+    expect(find.byKey(const ValueKey('study_selection_list')), findsOneWidget);
+    expect(StudyUDriverState.visibleStudies, isNot(same(staleStudies)));
+  });
+}
+
+extension _StudyUWidgetTester on WidgetTester {
+  Future<bool> waitForValueKey(String key, {required Duration timeout}) async {
+    final finder = find.byKey(ValueKey(key));
+    final deadline = binding.clock.fromNowBy(timeout);
+    while (binding.clock.now().isBefore(deadline)) {
+      await pump(const Duration(milliseconds: 100));
+      if (any(finder)) return true;
+    }
+    return any(finder);
+  }
+
+  Future<void> tapValueKey(String key) async {
+    final finder = find.byKey(ValueKey(key));
+    await ensureVisible(finder);
+    await tap(finder);
+    await pumpAndSettle();
+  }
+}

--- a/app/lib/driver_main.dart
+++ b/app/lib/driver_main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:studyu_app/main.dart' as app_main;
+import 'package:studyu_app/studyu_driver_state.dart';
 
 Future<void> main() async {
-  enableFlutterDriverExtension();
+  enableFlutterDriverExtension(handler: StudyUDriverState.handleRequest);
   await app_main.main();
 }

--- a/app/lib/screens/study/onboarding/study_selection.dart
+++ b/app/lib/screens/study/onboarding/study_selection.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/routes.dart';
+import 'package:studyu_app/studyu_driver_state.dart';
 import 'package:studyu_app/widgets/bottom_onboarding_navigation.dart';
 import 'package:studyu_app/widgets/study_tile.dart';
 import 'package:studyu_core/core.dart';
@@ -174,6 +175,10 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
                             });
                           });
                         }
+                        assert(() {
+                          StudyUDriverState.visibleStudies = studies;
+                          return true;
+                        }());
                         return ListView.builder(
                           key: const ValueKey('study_selection_list'),
                           itemCount: studies.length,
@@ -183,6 +188,7 @@ class _StudySelectionScreenState extends State<StudySelectionScreen> {
                               tag: 'study_tile_${studies[index].id}',
                               child: Material(
                                 child: StudyTile.fromStudy(
+                                  key: ValueKey('study_tile_${study.id}'),
                                   study: study,
                                   onTap: () async {
                                     await navigateToStudyOverview(

--- a/app/lib/studyu_driver_state.dart
+++ b/app/lib/studyu_driver_state.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import 'package:studyu_core/core.dart';
+
+class StudyUDriverState {
+  StudyUDriverState._();
+
+  static List<Study> visibleStudies = [];
+
+  static Future<String> handleRequest(String? message) async {
+    switch (message) {
+      case 'visibleStudies':
+        return jsonEncode({
+          'studies': visibleStudies.map(_studyToJson).toList(),
+        });
+      default:
+        return jsonEncode({
+          'error': 'Unsupported StudyU driver request',
+          'message': message,
+          'supportedMessages': ['visibleStudies'],
+        });
+    }
+  }
+
+  static Map<String, Object?> _studyToJson(Study study) => {
+    'id': study.id,
+    'title': study.title,
+    'description': study.description,
+    'status': study.status.name,
+    'participation': study.participation.name,
+    'registryPublished': study.registryPublished,
+  };
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -71,8 +71,10 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   lint: ^2.8.0
-
+  studyu_mcp: ^0.1.0
 flutter:
   generate: true
   uses-material-design: true

--- a/app/test_driver/integration_driver.dart
+++ b/app/test_driver/integration_driver.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1197,6 +1197,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  mcp_server:
+    dependency: transitive
+    description:
+      name: mcp_server
+      sha256: d5b2603a51b524c60753ea9031c52759f80b53dd6606f38ae70305b5eaa28d4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   melos:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - designer_v2
   - studyu_validator
   - tools/study_data_docs
+  - tools/studyu_mcp
 dev_dependencies:
   melos: ^8.0.0
 
@@ -156,6 +157,19 @@ melos:
         scope: studyu_app
       description: Runs StudyU App with local environment
 
+    local:app:driver:
+      run: |
+        melos exec -c 1 -- \
+          "flutter run -d chrome --web-port 8080 -t lib/driver_main.dart --dart-define=STUDYU_ENV=.env.local"
+      packageFilters:
+        scope: studyu_app
+      description: Runs StudyU App with local environment and Flutter Driver enabled
+
+    mcp:studyu:
+      run: |
+        cd tools/studyu_mcp && fvm dart run bin/studyu_mcp.dart
+      description: Runs the StudyU MCP server
+
     local:designer_v2:
       run: |
         melos exec -c 1 -- \
@@ -167,6 +181,19 @@ melos:
       packageFilters:
         scope: studyu_designer_v2
       description: Runs StudyU Designer with local environment
+
+    local:designer_v2:driver:
+      run: |
+        melos exec -c 1 -- \
+          "flutter run -d chrome --web-port 8081 \
+           -t lib/driver_main.dart \
+           --dart-define=STUDYU_ENV=.env.local \
+           --dart-define=EMAIL=user1@studyu.health \
+           --dart-define=PASSWORD=user1pass \
+           --dart-define=AUTO_LOGIN=false"
+      packageFilters:
+        scope: studyu_designer_v2
+      description: Runs StudyU Designer with local environment and Flutter Driver enabled
 
     build:android:
       run: |

--- a/tools/studyu_mcp/README.md
+++ b/tools/studyu_mcp/README.md
@@ -1,0 +1,82 @@
+# StudyU MCP
+
+StudyU MCP contains automation tools for StudyU development workflows.
+
+Current scope:
+
+- UI automation for the participant app and Designer v2 through Flutter Driver / VM service.
+- Reusable UI flow helpers for integration tests.
+- MCP tools for LLM-driven app navigation.
+
+Planned scope:
+
+- Study creation helpers.
+- Study validation helpers.
+- Combined study creation and UI testing workflows.
+
+## Package layout
+
+```text
+tools/studyu_mcp/
+  bin/
+    studyu_mcp.dart              # MCP server entrypoint
+  lib/
+    ui/
+      ui_driver.dart             # General UI contracts
+      vm_service_ui_driver.dart  # Flutter Driver / VM service adapter
+      app/                       # Participant app-specific UI tools
+      designer/                  # Designer v2-specific UI tools
+```
+
+## Run the MCP server
+
+From the repository root:
+
+```bash
+fvm exec melos run mcp:studyu
+```
+
+Or directly:
+
+```bash
+cd tools/studyu_mcp
+fvm dart run bin/studyu_mcp.dart
+```
+
+## Connect to a running Flutter app
+
+Start a driver-enabled app first.
+
+Participant app:
+
+```bash
+fvm exec melos run local:app:driver
+```
+
+Designer v2:
+
+```bash
+fvm exec melos run local:designer_v2:driver
+```
+
+Copy the VM service WebSocket URI from Flutter output:
+
+```text
+ws://127.0.0.1:<port>/<token>/ws
+```
+
+Then provide it to the MCP server through one of these paths:
+
+- Set `STUDYU_UI_VM_SERVICE_URI` before starting the MCP server.
+- Pass `vmServiceUri` to the `connect` MCP tool.
+
+Example:
+
+```bash
+export STUDYU_UI_VM_SERVICE_URI='ws://127.0.0.1:<port>/<token>/ws'
+fvm exec melos run mcp:studyu
+```
+
+## Docs
+
+- [UI MCP tools](docs/ui-mcp.md)

--- a/tools/studyu_mcp/bin/studyu_mcp.dart
+++ b/tools/studyu_mcp/bin/studyu_mcp.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:mcp_server/mcp_server.dart';
+import 'package:studyu_mcp/ui/app/app_mcp_tools.dart';
+import 'package:studyu_mcp/ui/app/app_ui_driver.dart';
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+import 'package:studyu_mcp/ui/designer/designer_ui_screen.dart';
+import 'package:studyu_mcp/ui/vm_service_ui_driver.dart';
+
+Future<void> main() async {
+  final server = Server(
+    name: 'studyu',
+    version: '0.1.0',
+    capabilities: ServerCapabilities.simple(tools: true),
+  );
+  final driver = StudyUUiDriver(
+    screenKeys: {...StudyUAppKey.all, ...StudyUDesignerKey.all},
+    inferScreen: _inferScreen,
+  );
+  final appDriver = StudyUAppUiDriver(driver);
+
+  server.addTool(
+    name: 'connect',
+    description:
+        'Connect to a running StudyU App or Designer Flutter process started with lib/driver_main.dart.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'vmServiceUri': {
+          'type': 'string',
+          'description':
+              'VM service WebSocket URI, for example ws://127.0.0.1:12345/abc=/ws. Defaults to STUDYU_UI_VM_SERVICE_URI or STUDYU_APP_VM_SERVICE_URI.',
+        },
+      },
+    },
+    handler: (arguments) async {
+      await driver.connect(arguments['vmServiceUri'] as String?);
+      return _jsonResult({'connected': true});
+    },
+  );
+
+  addStudyUAppTools(server, appDriver);
+  _addGeneralUiTools(server, driver);
+
+  final transportResult = McpServer.createStdioTransport();
+  final transport = transportResult.get();
+  server.connect(transport);
+  await transport.onClose;
+}
+
+void _addGeneralUiTools(Server server, StudyUUiDriver driver) {
+  server.addTool(
+    name: 'read_screen',
+    description:
+        'Return a compact non-visual screen snapshot inferred from visible ValueKeys.',
+    inputSchema: {'type': 'object', 'properties': {}},
+    handler: (_) async {
+      final snapshot = await driver.readScreen();
+      return _jsonResult(snapshot.toJson());
+    },
+  );
+
+  server.addTool(
+    name: 'tap_by_key',
+    description:
+        'Tap a visible widget by String ValueKey. Works for App and Designer.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'key': {'type': 'string'},
+      },
+      'required': ['key'],
+    },
+    handler: (arguments) async {
+      final key = arguments['key'] as String;
+      await driver.tapByValueKey(key);
+      return _jsonResult({'tapped': key});
+    },
+  );
+
+  server.addTool(
+    name: 'enter_text_by_key',
+    description:
+        'Focus a text field by String ValueKey and enter text. Works for App and Designer.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'key': {'type': 'string'},
+        'text': {'type': 'string'},
+      },
+      'required': ['key', 'text'],
+    },
+    handler: (arguments) async {
+      final key = arguments['key'] as String;
+      final text = arguments['text'] as String;
+      await driver.enterTextByValueKey(key, text);
+      return _jsonResult({'enteredTextInto': key});
+    },
+  );
+}
+
+CallToolResult _jsonResult(Map<String, Object?> value) => CallToolResult(
+  content: [
+    TextContent(text: const JsonEncoder.withIndent('  ').convert(value)),
+  ],
+);
+
+String _inferScreen(Set<String> keys) {
+  final appScreen = inferStudyUAppScreen(keys);
+  if (appScreen != StudyUAppScreen.unknown) return appScreen;
+  return inferStudyUDesignerScreen(keys) ?? StudyUAppScreen.unknown;
+}

--- a/tools/studyu_mcp/docs/ui-mcp.md
+++ b/tools/studyu_mcp/docs/ui-mcp.md
@@ -1,0 +1,191 @@
+# UI MCP tools
+
+The UI MCP tools drive a running StudyU Flutter app through the Flutter Driver service extension.
+They do not use screenshots. They inspect known `ValueKey` widgets and call Flutter Driver commands
+through the VM service.
+
+## Start a driver-enabled app
+
+Participant app:
+
+```bash
+fvm exec melos run local:app:driver
+```
+
+Designer v2:
+
+```bash
+fvm exec melos run local:designer_v2:driver
+```
+
+Flutter prints a VM service URI:
+
+```text
+ws://127.0.0.1:<port>/<token>/ws
+```
+
+Set it before starting the MCP server:
+
+```bash
+export STUDYU_UI_VM_SERVICE_URI='ws://127.0.0.1:<port>/<token>/ws'
+fvm exec melos run mcp:studyu
+```
+
+You can also pass the URI to the `connect` tool. Connections are restricted to
+`localhost`, `127.0.0.1`, and `::1`.
+
+## General UI tools
+
+### `connect`
+
+Connects the MCP server to a running app or Designer v2 process.
+
+Input:
+
+```json
+{
+  "vmServiceUri": "ws://127.0.0.1:<port>/<token>/ws"
+}
+```
+
+`vmServiceUri` is optional when `STUDYU_UI_VM_SERVICE_URI` is set.
+
+### `read_screen`
+
+Returns a compact screen snapshot inferred from visible `ValueKey`s.
+
+Example output:
+
+```json
+{
+  "screen": "StudySelectionScreen",
+  "visibleKeys": [
+    "study_selection_invite_code",
+    "study_selection_list"
+  ]
+}
+```
+
+### `tap_by_key`
+
+Taps a visible widget by String `ValueKey`.
+
+Input:
+
+```json
+{
+  "key": "login_button"
+}
+```
+
+### `enter_text_by_key`
+
+Focuses a text field by String `ValueKey` and enters text.
+
+Input:
+
+```json
+{
+  "key": "login_email",
+  "text": "user1@studyu.health"
+}
+```
+
+## Participant app tools
+
+### `app_complete_onboarding_to_study_list`
+
+Runs the participant app onboarding and legal flow until the study list appears. Returns the visible
+study list.
+
+Input:
+
+```json
+{
+  "vmServiceUri": "ws://127.0.0.1:<port>/<token>/ws"
+}
+```
+
+`vmServiceUri` is optional when the MCP server is connected.
+
+Example output:
+
+```json
+{
+  "screen": "StudySelectionScreen",
+  "studies": [
+    {
+      "id": "...",
+      "title": "Public demo study of user1",
+      "description": "This is a Demo Study.",
+      "status": "running",
+      "participation": "open",
+      "registryPublished": true
+    }
+  ]
+}
+```
+
+### `app_get_visible_studies`
+
+Returns the current study list. Use it only when the app is already on `StudySelectionScreen`.
+
+### `app_recover_state`
+
+Attempts to recover the app to `StudySelectionScreen`, then returns the screen snapshot and visible
+studies.
+
+Current recovery behavior:
+
+- `OnboardingScreen`: taps through onboarding.
+- `WelcomeScreen`: opens the legal flow.
+- `TermsScreen`: accepts terms and privacy.
+- `StudySelectionScreen`: returns without navigation.
+- `StudyOverviewScreen`: fails with a state error because recovery would require back navigation.
+
+### `app_open_study`
+
+Opens one visible app study by id.
+
+Input:
+
+```json
+{
+  "studyId": "<study-id>"
+}
+```
+
+## Designer v2 support
+
+Current Designer v2 support covers general UI primitives:
+
+- `read_screen`
+- `tap_by_key`
+- `enter_text_by_key`
+
+Known Designer v2 screen inference:
+
+- `DesignerLoginScreen`
+- `DesignerStudiesScreen`
+- `DesignerStudyEditorScreen`
+
+Designer-specific MCP tools should live under `lib/ui/designer/` when added.
+
+## Integration test reuse
+
+App integration tests can reuse the same app flow without MCP:
+
+```dart
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+
+final flow = StudyUAppUiFlow(
+  waitForKey: (key, {required timeout}) =>
+      tester.waitForValueKey(
+        key,
+        timeout: timeout,
+      ),
+  tapKey: tester.tapValueKey,
+);
+
+await flow.completeOnboardingToStudyList();
+```

--- a/tools/studyu_mcp/lib/ui/app/app_mcp_tools.dart
+++ b/tools/studyu_mcp/lib/ui/app/app_mcp_tools.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:mcp_server/mcp_server.dart';
+import 'package:studyu_mcp/ui/app/app_ui_driver.dart';
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+
+void addStudyUAppTools(Server server, StudyUAppUiDriver appDriver) {
+  server.addTool(
+    name: 'app_complete_onboarding_to_study_list',
+    description:
+        'Navigate the StudyU App onboarding/legal flow to StudySelectionScreen, then return the dynamic study list.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'vmServiceUri': {
+          'type': 'string',
+          'description':
+              'Optional VM service WebSocket URI. If omitted, uses existing connection, STUDYU_UI_VM_SERVICE_URI, or STUDYU_APP_VM_SERVICE_URI.',
+        },
+      },
+    },
+    handler: (arguments) async {
+      await appDriver.connect(arguments['vmServiceUri'] as String?);
+      final studies = await appDriver.completeOnboardingToStudyList();
+      return _jsonResult({
+        'screen': StudyUAppScreen.studySelection,
+        'studies': studies,
+      });
+    },
+  );
+
+  server.addTool(
+    name: 'app_get_visible_studies',
+    description:
+        'Return studies currently visible on StudySelectionScreen as structured JSON for LLM selection.',
+    inputSchema: {'type': 'object', 'properties': {}},
+    handler: (_) async {
+      final studies = await appDriver.visibleStudies();
+      return _jsonResult({
+        'screen': StudyUAppScreen.studySelection,
+        'studies': studies,
+      });
+    },
+  );
+
+  server.addTool(
+    name: 'app_recover_state',
+    description:
+        'Read current app state and recover to StudySelectionScreen when possible.',
+    inputSchema: {'type': 'object', 'properties': {}},
+    handler: (_) async {
+      final studies = await appDriver.completeOnboardingToStudyList();
+      final snapshot = await appDriver.readScreen();
+      return _jsonResult({...snapshot.toJson(), 'studies': studies});
+    },
+  );
+
+  server.addTool(
+    name: 'app_open_study',
+    description: 'Open one visible StudyU App study by its study id.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'studyId': {'type': 'string'},
+      },
+      'required': ['studyId'],
+    },
+    handler: (arguments) async {
+      final studyId = arguments['studyId'] as String;
+      await appDriver.openStudy(studyId);
+      return _jsonResult({
+        'screen': StudyUAppScreen.studyOverview,
+        'studyId': studyId,
+      });
+    },
+  );
+}
+
+CallToolResult _jsonResult(Map<String, Object?> value) => CallToolResult(
+  content: [
+    TextContent(text: const JsonEncoder.withIndent('  ').convert(value)),
+  ],
+);

--- a/tools/studyu_mcp/lib/ui/app/app_ui_driver.dart
+++ b/tools/studyu_mcp/lib/ui/app/app_ui_driver.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+import 'package:studyu_mcp/ui/ui_driver.dart';
+import 'package:studyu_mcp/ui/vm_service_ui_driver.dart';
+
+class StudyUAppUiDriver {
+  const StudyUAppUiDriver(this._driver);
+
+  final StudyUUiDriver _driver;
+
+  Future<void> connect(String? vmServiceUri) => _driver.connect(vmServiceUri);
+
+  Future<StudyUIScreenSnapshot> readScreen() => _driver.readScreen();
+
+  Future<List<Object?>> completeOnboardingToStudyList() async {
+    await StudyUAppUiFlow(
+      waitForKey: _driver.waitForValueKey,
+      tapKey: _driver.tapByValueKey,
+      readScreen: _driver.readScreen,
+    ).completeOnboardingToStudyList();
+    return visibleStudies();
+  }
+
+  Future<List<Object?>> visibleStudies() async {
+    final response = await _driver.requestData('visibleStudies');
+    final message = response['message'] as String?;
+    if (message == null) return [];
+    final decoded = jsonDecode(message) as Map<String, dynamic>;
+    return (decoded['studies'] as List?) ?? [];
+  }
+
+  Future<void> openStudy(String studyId) =>
+      _driver.tapByValueKey('study_tile_$studyId');
+}

--- a/tools/studyu_mcp/lib/ui/app/app_ui_flow.dart
+++ b/tools/studyu_mcp/lib/ui/app/app_ui_flow.dart
@@ -1,0 +1,181 @@
+import 'package:studyu_mcp/ui/ui_driver.dart';
+
+class StudyUAppUiFlow {
+  const StudyUAppUiFlow({
+    required StudyUWaitForKey waitForKey,
+    required StudyUTapKey tapKey,
+    StudyUReadScreen? readScreen,
+    this.shortTimeout = const Duration(milliseconds: 800),
+    this.routeTimeout = const Duration(seconds: 1),
+    this.finalTimeout = const Duration(seconds: 10),
+  }) : _waitForKey = waitForKey,
+       _tapKey = tapKey,
+       _readScreen = readScreen;
+
+  final StudyUWaitForKey _waitForKey;
+  final StudyUTapKey _tapKey;
+  final StudyUReadScreen? _readScreen;
+  final Duration shortTimeout;
+  final Duration routeTimeout;
+  final Duration finalTimeout;
+
+  Future<void> completeOnboardingToStudyList() async {
+    final snapshot = await _readCurrentScreen();
+    switch (snapshot.screen) {
+      case StudyUAppScreen.studySelection:
+        return;
+      case StudyUAppScreen.studyOverview:
+        throw StateError(
+          'Already past StudySelectionScreen. Go back before completing onboarding.',
+        );
+    }
+
+    if (snapshot.screen == StudyUAppScreen.unknown ||
+        snapshot.screen == StudyUAppScreen.onboarding ||
+        snapshot.hasKey(StudyUAppKey.onboardingNext) ||
+        snapshot.hasKey(StudyUAppKey.onboardingDone)) {
+      await _completeIntroPages();
+    }
+
+    if (!await _isOnStudySelection()) {
+      await _tapIfPresent(StudyUAppKey.welcomeGetStarted);
+    }
+    if (!await _isOnStudySelection()) {
+      await _tapIfPresent(StudyUAppKey.termsContinue);
+    }
+    if (!await _isOnStudySelection()) {
+      await _acceptTerms();
+    }
+
+    final reachedStudyList = await _waitForKey(
+      StudyUAppKey.studySelectionList,
+      timeout: finalTimeout,
+    );
+    if (!reachedStudyList) {
+      final current = await _readCurrentScreen();
+      throw StateError(
+        'Study selection list did not become visible. Current screen: ${current.screen}. Visible keys: ${current.visibleKeys.join(', ')}',
+      );
+    }
+  }
+
+  Future<void> _completeIntroPages() async {
+    for (var i = 0; i < 4; i++) {
+      await _tapIfPresent(StudyUAppKey.onboardingNext);
+    }
+    await _tapIfPresent(StudyUAppKey.onboardingDone);
+  }
+
+  Future<void> _acceptTerms() async {
+    await _tapIfPresent(StudyUAppKey.termsCheckbox);
+    await _tapIfPresent(StudyUAppKey.privacyCheckbox);
+    await _tapIfPresent(StudyUAppKey.termsContinue);
+  }
+
+  Future<bool> _isOnStudySelection() =>
+      _waitForKey(StudyUAppKey.studySelectionList, timeout: routeTimeout);
+
+  Future<StudyUIScreenSnapshot> _readCurrentScreen() async {
+    final reader = _readScreen;
+    if (reader == null) {
+      return const StudyUIScreenSnapshot(
+        screen: StudyUAppScreen.unknown,
+        visibleKeys: {},
+      );
+    }
+    return reader();
+  }
+
+  Future<void> _tapIfPresent(String key) async {
+    if (await _waitForKey(key, timeout: shortTimeout)) {
+      await _tapKey(key);
+    }
+  }
+}
+
+abstract final class StudyUAppKey {
+  static const onboardingNext = 'onboarding_next';
+  static const onboardingDone = 'onboarding_done';
+  static const welcomeGetStarted = 'welcome_get_started';
+  static const termsCheckbox = 'terms_checkbox';
+  static const privacyCheckbox = 'privacy_checkbox';
+  static const termsContinue = 'terms_continue';
+  static const studySelectionList = 'study_selection_list';
+  static const studySelectionInviteCode = 'study_selection_invite_code';
+  static const studyOverviewScreen = 'study_overview_screen';
+  static const studyOverviewNext = 'study_overview_next';
+  static const eligibilityScreen = 'eligibility_screen';
+  static const eligibilityContinue = 'eligibility_continue';
+  static const interventionSelectionScreen = 'intervention_selection_screen';
+  static const interventionSelectionContinue =
+      'intervention_selection_continue';
+  static const journeyOverviewScreen = 'journey_overview_screen';
+  static const journeyOverviewNext = 'journey_overview_next';
+  static const consentAccept = 'consent_accept';
+
+  static const all = [
+    onboardingNext,
+    onboardingDone,
+    welcomeGetStarted,
+    termsCheckbox,
+    privacyCheckbox,
+    termsContinue,
+    studySelectionList,
+    studySelectionInviteCode,
+    studyOverviewScreen,
+    studyOverviewNext,
+    eligibilityScreen,
+    eligibilityContinue,
+    interventionSelectionScreen,
+    interventionSelectionContinue,
+    journeyOverviewScreen,
+    journeyOverviewNext,
+    consentAccept,
+  ];
+}
+
+abstract final class StudyUAppScreen {
+  static const unknown = 'unknown';
+  static const onboarding = 'OnboardingScreen';
+  static const welcome = 'WelcomeScreen';
+  static const terms = 'TermsScreen';
+  static const studySelection = 'StudySelectionScreen';
+  static const studyOverview = 'StudyOverviewScreen';
+  static const eligibility = 'EligibilityScreen';
+  static const interventionSelection = 'InterventionSelectionScreen';
+  static const journeyOverview = 'JourneyOverviewScreen';
+  static const consent = 'ConsentScreen';
+}
+
+String inferStudyUAppScreen(Set<String> keys) {
+  if (keys.contains(StudyUAppKey.studySelectionList)) {
+    return StudyUAppScreen.studySelection;
+  }
+  if (keys.contains(StudyUAppKey.studyOverviewScreen)) {
+    return StudyUAppScreen.studyOverview;
+  }
+  if (keys.contains(StudyUAppKey.eligibilityScreen)) {
+    return StudyUAppScreen.eligibility;
+  }
+  if (keys.contains(StudyUAppKey.interventionSelectionScreen)) {
+    return StudyUAppScreen.interventionSelection;
+  }
+  if (keys.contains(StudyUAppKey.journeyOverviewScreen)) {
+    return StudyUAppScreen.journeyOverview;
+  }
+  if (keys.contains(StudyUAppKey.consentAccept)) {
+    return StudyUAppScreen.consent;
+  }
+  if (keys.contains(StudyUAppKey.welcomeGetStarted)) {
+    return StudyUAppScreen.welcome;
+  }
+  if (keys.contains(StudyUAppKey.termsContinue) ||
+      keys.contains(StudyUAppKey.termsCheckbox)) {
+    return StudyUAppScreen.terms;
+  }
+  if (keys.contains(StudyUAppKey.onboardingNext) ||
+      keys.contains(StudyUAppKey.onboardingDone)) {
+    return StudyUAppScreen.onboarding;
+  }
+  return StudyUAppScreen.unknown;
+}

--- a/tools/studyu_mcp/lib/ui/designer/designer_ui_screen.dart
+++ b/tools/studyu_mcp/lib/ui/designer/designer_ui_screen.dart
@@ -1,0 +1,56 @@
+abstract final class StudyUDesignerKey {
+  static const loginEmail = 'login_email';
+  static const loginPassword = 'login_password';
+  static const loginButton = 'login_button';
+  static const signupEmail = 'signup_email';
+  static const signupPassword = 'signup_password';
+  static const signupButton = 'signup_button';
+  static const newStudyButton = 'new_study_button';
+  static const newStudyCompactButton = 'new_study_compact_button';
+  static const studiesTableRows = 'studies_table_rows';
+  static const filterToggleButton = 'filter_toggle_button';
+  static const searchButton = 'search_button';
+  static const navbarTabBar = 'navbar_tab_bar';
+  static const formSaveButton = 'form_save_button';
+  static const formCancelButton = 'form_cancel_button';
+
+  static const all = [
+    loginEmail,
+    loginPassword,
+    loginButton,
+    signupEmail,
+    signupPassword,
+    signupButton,
+    newStudyButton,
+    newStudyCompactButton,
+    studiesTableRows,
+    filterToggleButton,
+    searchButton,
+    navbarTabBar,
+    formSaveButton,
+    formCancelButton,
+  ];
+}
+
+abstract final class StudyUDesignerScreen {
+  static const login = 'DesignerLoginScreen';
+  static const studies = 'DesignerStudiesScreen';
+  static const studyEditor = 'DesignerStudyEditorScreen';
+}
+
+String? inferStudyUDesignerScreen(Set<String> keys) {
+  if (keys.contains(StudyUDesignerKey.loginEmail) ||
+      keys.contains(StudyUDesignerKey.loginButton)) {
+    return StudyUDesignerScreen.login;
+  }
+  if (keys.contains(StudyUDesignerKey.studiesTableRows) ||
+      keys.contains(StudyUDesignerKey.newStudyButton) ||
+      keys.contains(StudyUDesignerKey.newStudyCompactButton)) {
+    return StudyUDesignerScreen.studies;
+  }
+  if (keys.contains(StudyUDesignerKey.navbarTabBar) ||
+      keys.contains(StudyUDesignerKey.formSaveButton)) {
+    return StudyUDesignerScreen.studyEditor;
+  }
+  return null;
+}

--- a/tools/studyu_mcp/lib/ui/ui_driver.dart
+++ b/tools/studyu_mcp/lib/ui/ui_driver.dart
@@ -1,0 +1,23 @@
+typedef StudyUReadScreen = Future<StudyUIScreenSnapshot> Function();
+
+typedef StudyUWaitForKey =
+    Future<bool> Function(String key, {required Duration timeout});
+
+typedef StudyUTapKey = Future<void> Function(String key);
+
+class StudyUIScreenSnapshot {
+  const StudyUIScreenSnapshot({
+    required this.screen,
+    required this.visibleKeys,
+  });
+
+  final String screen;
+  final Set<String> visibleKeys;
+
+  bool hasKey(String key) => visibleKeys.contains(key);
+
+  Map<String, Object?> toJson() => {
+    'screen': screen,
+    'visibleKeys': visibleKeys.toList()..sort(),
+  };
+}

--- a/tools/studyu_mcp/lib/ui/vm_service_ui_driver.dart
+++ b/tools/studyu_mcp/lib/ui/vm_service_ui_driver.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:studyu_mcp/ui/ui_driver.dart';
+import 'package:vm_service/vm_service.dart' as vm;
+import 'package:vm_service/vm_service_io.dart';
+
+class StudyUUiDriver {
+  StudyUUiDriver({
+    required Set<String> screenKeys,
+    required String Function(Set<String> keys) inferScreen,
+  }) : _screenKeys = screenKeys,
+       _inferScreen = inferScreen;
+
+  final Set<String> _screenKeys;
+  final String Function(Set<String> keys) _inferScreen;
+  vm.VmService? _service;
+  String? _isolateId;
+
+  Future<void> connect(String? vmServiceUri) async {
+    if (_service != null && _isolateId != null && vmServiceUri == null) return;
+
+    final uri =
+        vmServiceUri ??
+        Platform.environment['STUDYU_UI_VM_SERVICE_URI'] ??
+        Platform.environment['STUDYU_APP_VM_SERVICE_URI'];
+    if (uri == null || uri.isEmpty) {
+      throw StateError(
+        'Missing vmServiceUri. Start app/lib/driver_main.dart or designer_v2/lib/driver_main.dart and pass its VM service ws://.../ws URI, or set STUDYU_UI_VM_SERVICE_URI.',
+      );
+    }
+
+    _service = await vmServiceConnectUri(normalizeVmServiceUri(uri));
+    final isolates = (await _service!.getVM()).isolates ?? [];
+    final mainIsolate = isolates
+        .where((isolate) => isolate.id != null)
+        .firstWhere(
+          (isolate) => isolate.name == 'main',
+          orElse: () =>
+              throw StateError('No main isolate found in VM service.'),
+        );
+    _isolateId = mainIsolate.id;
+    await _driverCommand({'command': 'get_health'});
+  }
+
+  Future<StudyUIScreenSnapshot> readScreen() async {
+    final visibleKeys = <String>{};
+    for (final key in _screenKeys) {
+      if (await waitForValueKey(
+        key,
+        timeout: const Duration(milliseconds: 100),
+      )) {
+        visibleKeys.add(key);
+      }
+    }
+
+    return StudyUIScreenSnapshot(
+      screen: _inferScreen(visibleKeys),
+      visibleKeys: visibleKeys,
+    );
+  }
+
+  Future<void> tapByValueKey(String key) => _tapByValueKey(key);
+
+  Future<void> enterTextByValueKey(String key, String text) async {
+    await _tapByValueKey(key);
+    await _driverCommand({'command': 'enter_text', 'text': text});
+  }
+
+  Future<Map<String, dynamic>> requestData(String message) =>
+      _driverCommand({'command': 'request_data', 'message': message});
+
+  Future<bool> waitForValueKey(String key, {required Duration timeout}) async {
+    try {
+      await _driverCommand({
+        'command': 'waitFor',
+        ..._byValueKey(key),
+        'timeout': '${timeout.inMilliseconds}',
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> _tapByValueKey(String key) async {
+    await _driverCommand({'command': 'tap', ..._byValueKey(key)});
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+
+  Future<Map<String, dynamic>> _driverCommand(Map<String, String> args) async {
+    final service = _service;
+    final isolateId = _isolateId;
+    if (service == null || isolateId == null) {
+      throw StateError('Not connected. Call connect first.');
+    }
+
+    final response = await service.callServiceExtension(
+      'ext.flutter.driver',
+      isolateId: isolateId,
+      args: args,
+    );
+    final json = response.json;
+    if (json == null) return {};
+    final isError = json['isError'] as bool? ?? false;
+    if (isError) {
+      throw StateError('${json['response']}');
+    }
+    return (json['response'] as Map?)?.cast<String, dynamic>() ?? {};
+  }
+}
+
+Map<String, String> _byValueKey(String key) => {
+  'finderType': 'ByValueKey',
+  'keyValueString': key,
+  'keyValueType': 'String',
+};
+
+String normalizeVmServiceUri(String value) {
+  final uri = Uri.parse(value);
+  final scheme = switch (uri.scheme) {
+    'http' => 'ws',
+    'https' => 'wss',
+    'ws' || 'wss' => uri.scheme,
+    _ => throw const FormatException(
+      'VM service URI must use HTTP or WebSocket.',
+    ),
+  };
+  if (!{'localhost', '127.0.0.1', '::1'}.contains(uri.host.toLowerCase())) {
+    throw const FormatException('VM service URI must use a loopback host.');
+  }
+  final path = uri.path.endsWith('/ws') ? uri.path : '${uri.path}/ws';
+  return uri.replace(scheme: scheme, path: path).toString();
+}

--- a/tools/studyu_mcp/pubspec.yaml
+++ b/tools/studyu_mcp/pubspec.yaml
@@ -1,0 +1,14 @@
+name: studyu_mcp
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  mcp_server: ^2.0.0
+  vm_service: ^15.2.0
+
+dev_dependencies:
+  test: ^1.30.0

--- a/tools/studyu_mcp/test/app_ui_flow_test.dart
+++ b/tools/studyu_mcp/test/app_ui_flow_test.dart
@@ -1,0 +1,52 @@
+import 'package:studyu_mcp/ui/app/app_ui_flow.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('completes onboarding and legal steps', () async {
+    final visibleKeys = {StudyUAppKey.onboardingNext};
+    var introPage = 0;
+    var legalFormShown = false;
+
+    await StudyUAppUiFlow(
+      shortTimeout: Duration.zero,
+      routeTimeout: Duration.zero,
+      finalTimeout: Duration.zero,
+      waitForKey: (key, {required timeout}) async => visibleKeys.contains(key),
+      tapKey: (key) async {
+        switch (key) {
+          case StudyUAppKey.onboardingNext:
+            if (++introPage == 4) {
+              visibleKeys
+                ..remove(key)
+                ..add(StudyUAppKey.onboardingDone);
+            }
+          case StudyUAppKey.onboardingDone:
+            visibleKeys
+              ..remove(key)
+              ..add(StudyUAppKey.welcomeGetStarted);
+          case StudyUAppKey.welcomeGetStarted:
+            visibleKeys
+              ..remove(key)
+              ..add(StudyUAppKey.termsContinue);
+          case StudyUAppKey.termsContinue:
+            if (legalFormShown) {
+              visibleKeys
+                ..clear()
+                ..add(StudyUAppKey.studySelectionList);
+            } else {
+              legalFormShown = true;
+              visibleKeys.addAll({
+                StudyUAppKey.termsCheckbox,
+                StudyUAppKey.privacyCheckbox,
+              });
+            }
+          case StudyUAppKey.termsCheckbox:
+          case StudyUAppKey.privacyCheckbox:
+            visibleKeys.remove(key);
+        }
+      },
+    ).completeOnboardingToStudyList();
+
+    expect(visibleKeys, contains(StudyUAppKey.studySelectionList));
+  });
+}

--- a/tools/studyu_mcp/test/vm_service_ui_driver_test.dart
+++ b/tools/studyu_mcp/test/vm_service_ui_driver_test.dart
@@ -1,0 +1,27 @@
+import 'package:studyu_mcp/ui/vm_service_ui_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeVmServiceUri', () {
+    test('normalizes a loopback HTTP URI', () {
+      expect(
+        normalizeVmServiceUri('http://127.0.0.1:1234/token='),
+        'ws://127.0.0.1:1234/token=/ws',
+      );
+    });
+
+    test('accepts loopback WebSocket URIs', () {
+      expect(
+        normalizeVmServiceUri('ws://localhost:1234/token=/ws'),
+        'ws://localhost:1234/token=/ws',
+      );
+    });
+
+    test('rejects non-loopback hosts', () {
+      expect(
+        () => normalizeVmServiceUri('ws://example.com:1234/token=/ws'),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds a repository-owned MCP server for driving the participant app and Designer v2 through Flutter Driver and the Dart VM service.

- Registers `tools/studyu_mcp` as a workspace package with MCP and VM-service dependencies.
- Adds participant-app tools for onboarding recovery, visible-study inspection, and study selection.
- Handles onboarding, Welcome, Terms, study selection, and known Designer screens.
- Restricts VM-service connections to loopback hosts.
- Exposes driver-enabled Melos commands for the app and Designer.
- Reuses the onboarding flow from an app integration test and runs it in the web E2E workflow.

This is a stacked PR targeting #866. After #866 merges, rebase this branch onto `dev` with `--force-with-lease` and retarget the PR.

## Visuals
<!-- REQUIRED: Attach a screenshot for static changes or a screen recording for interactive changes -->

## Testing Steps

1. Start local Supabase and configure `flutter_common/lib/envs/.env.local`.
2. Run `fvm exec melos run local:app:driver`.
3. Copy the printed VM-service URI and set `STUDYU_UI_VM_SERVICE_URI`.
4. Run `fvm exec melos run mcp:studyu` and connect through an MCP client.
5. Verify `read_screen`, `app_complete_onboarding_to_study_list`, and `app_get_visible_studies`.

### PR Checklist
- [ ] `fvm exec melos run qualitycheck` passes
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analyzers pass via `scripts/pre-commit-check`
- [x] `cd tools/studyu_mcp && fvm dart test` passes
- [x] App integration-test target builds for web
- [x] E2E workflow passes `actionlint`
- [ ] Screenshot or video of the changes attached
- [ ] Description links related issues