### PR TITLE
chore: enforce dart file length limits

### DIFF
--- a/.github/workflows/dart_file_lines.yml
+++ b/.github/workflows/dart_file_lines.yml
@@ -1,0 +1,28 @@
+name: Dart File Lines
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dart-file-lines-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check Dart file lengths
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: scripts/check-dart-file-lengths "$BASE_REF"

--- a/.github/workflows/ready_to_merge.yml
+++ b/.github/workflows/ready_to_merge.yml
@@ -15,15 +15,18 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // Define a list of workflows that need to finish successfully if run before merging  
+            // Define the workflows that need to finish successfully before merging.
             workflows_to_check = [
               "all_packages.yml",
+              "dart_file_lines.yml",
               "linter.yml",
               "mega-linter.yml",
               "e2e_tests.yml",
               "supabase-test.yml",
             ];
-            console.log("Initializing with workflows to check: " + workflows_to_check);
+            console.log(
+              "Initializing with workflows to check: " + workflows_to_check
+            );
             const { owner, repo } = context.repo;
             let branch_name;
             if (context.payload.pull_request !== undefined) {
@@ -35,7 +38,7 @@ jobs:
             }
             console.log("Branch name: " + branch_name);
             const maxRetries = 15; // Maximum number of retries
-            
+
             async function fetchLatestWorkflowRun(workflowId) {
               console.log("Fetching workflow runs for: " + workflowId);
               try {
@@ -49,10 +52,17 @@ jobs:
                 return response.data.workflow_runs[0];
               } catch (error) {
                 if (error.status === 404) {
-                  console.warn("Workflow not found: " + workflowId + ". It will be ignored.");
+                  console.warn(
+                    "Workflow not found: " + workflowId + ". It will be ignored."
+                  );
                   return;
                 }
-                core.setFailed("Error fetching workflow runs for: " + workflowId + ". Error: " + error.message);
+                core.setFailed(
+                  "Error fetching workflow runs for: " +
+                  workflowId +
+                  ". Error: " +
+                  error.message
+                );
                 process.exit();
               }
             }
@@ -60,7 +70,7 @@ jobs:
             async function sleep(ms) {
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
-            
+
             console.log("Sleeping 10s to give other runs a chance to start");
             await sleep(10000);
             for (const workflowId of workflows_to_check) {
@@ -72,15 +82,31 @@ jobs:
                 continue;
               }
               do {
-                console.log("Checking workflow run: " + workflowRun.name + " with status: " + workflowRun.status + " and conclusion: " + workflowRun.conclusion);
+                console.log(
+                  "Checking workflow run: " +
+                  workflowRun.name +
+                  " with status: " +
+                  workflowRun.status +
+                  " and conclusion: " +
+                  workflowRun.conclusion
+                );
                 if (retryCount >= maxRetries) {
                   core.setFailed(
                     "Maximum retries reached with check runs still in progress."
                   );
                   break;
                 }
-                if (workflowRun.conclusion === "success" || workflowRun.conclusion === "skipped" || workflowRun.conclusion === "cancelled") {
-                  console.log("Workflow run completed successfully: " + workflowRun.name + " with conclusion: " + workflowRun.conclusion);
+                if (
+                  workflowRun.conclusion === "success" ||
+                  workflowRun.conclusion === "skipped" ||
+                  workflowRun.conclusion === "cancelled"
+                ) {
+                  console.log(
+                    "Workflow run completed successfully: " +
+                    workflowRun.name +
+                    " with conclusion: " +
+                    workflowRun.conclusion
+                  );
                   break;
                 }
                 if (workflowRun.conclusion === "failure") {
@@ -95,9 +121,12 @@ jobs:
                   const failedCheckNames = checkRuns.data.check_runs
                       .filter((checkRun) => checkRun.conclusion === "failure")
                       .map((checkRun) => checkRun.name);
-                  core.setFailed("The workflow run '" +
-                    workflowRun.name + "' has failed. Please fix the failed checks: '" +
-                    failedCheckNames.join(", ") + "'. Check suite URL: " +
+                  core.setFailed(
+                    "The workflow run '" +
+                    workflowRun.name +
+                    "' has failed. Please fix the failed checks: '" +
+                    failedCheckNames.join(", ") +
+                    "'. Check suite URL: " +
                     urlOfFailedCheckSuite
                   );
                   break;
@@ -110,15 +139,16 @@ jobs:
             }
             console.log("All given workflow runs completed.");
 
-            // Do not check the check runs for now, since fetchCheckRuns also 
+            // Do not check the check runs for now, since fetchCheckRuns also
             // includes the workflows we checked above for the latest commit.
-            // Todo: find another way to check for checks that are not part 
-            // of this repository e.g. GitGuardian
+            // Todo: find another way to check for checks that are not part
+            // of this repository e.g. GitGuardian.
 
-            /* 
-              const commit_sha = context.payload.pull_request.head.sha; // Get the SHA of the head commit of the PR
+            /*
+              const commit_sha = context.payload.pull_request.head.sha;
+              // Get the SHA of the head commit of the PR
               console.log("commit_sha " + commit_sha);
-              // exclude the current workflow from the list of workflows to check
+              // Exclude the current workflow from the workflows checked above.
               const excludedCheckRunName = 'check_commit_status'
               // console.log("context sha: " + context.sha);
               // console.log("github sha: " + github.sha);
@@ -129,7 +159,9 @@ jobs:
                   ref: commit_sha,
                   per_page: 100,
                 });
-                console.log("Found " + response.data.check_runs.length + " check runs.");
+                console.log(
+                  "Found " + response.data.check_runs.length + " check runs."
+                );
                 return response.data.check_runs;
               }
               console.log("Checking check runs...");
@@ -139,16 +171,26 @@ jobs:
                 let retryCount = 0;
                 do {
                   inProgressFound = false;
-                  console.log("Checking check run: " + checkRun.name + " with status: " + checkRun.status + " and conclusion: " + checkRun.conclusion);
+                  console.log(
+                    "Checking check run: " +
+                    checkRun.name +
+                    " with status: " +
+                    checkRun.status +
+                    " and conclusion: " +
+                    checkRun.conclusion
+                  );
                   if (checkRun.name === excludedCheckRunName) {
-                    console.log("Skipping excluded check run: " + checkRun.name);
+                    console.log(
+                      "Skipping excluded check run: " + checkRun.name
+                    );
                     break;
                   }
                   if (checkRun.status === "in_progress") {
                     console.log("Check run in progress: " + checkRun.name);
                     if (retryCount >= maxRetries) {
                       core.setFailed(
-                        "Maximum retries reached with check runs still in progress."
+                        "Maximum retries reached with check runs still in " +
+                        "progress."
                       );
                       break;
                     }
@@ -159,8 +201,11 @@ jobs:
                     inProgressFound = true;
                   }
                   if (checkRun.conclusion === "failure") {
-                    core.setFailed("The check run '" +
-                      checkRun.name + "' has failed. Please fix the failed checks. Check run URL: " +
+                    core.setFailed(
+                      "The check run '" +
+                      checkRun.name +
+                      "' has failed. Please fix the failed checks. " +
+                      "Check run URL: " +
                       checkRun.html_url
                     );
                   }

--- a/scripts/check-dart-file-lengths
+++ b/scripts/check-dart-file-lengths
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf 'Usage: %s BASE_REF\n' "$0" >&2
+  exit 2
+fi
+
+base_ref=$1
+base_commit=$(git rev-parse --verify "$base_ref^{commit}")
+merge_base=$(git merge-base "$base_commit" HEAD)
+
+status_file=$(mktemp "${TMPDIR:-/tmp}/check-dart-file-lengths.XXXXXX")
+trap 'rm -f "$status_file"' EXIT
+
+git diff --name-status -z --find-renames --diff-filter=AMR "$merge_base" HEAD -- '*.dart' > "$status_file"
+
+escape_message() {
+  local value=$1
+  value=${value//%/%25}
+  value=${value//$'\r'/%0D}
+  value=${value//$'\n'/%0A}
+  printf '%s' "$value"
+}
+
+escape_property() {
+  local value
+  value=$(escape_message "$1")
+  value=${value//:/%3A}
+  value=${value//,/%2C}
+  printf '%s' "$value"
+}
+
+count_lines() {
+  awk 'END { print NR }' < "$1"
+}
+
+count_base_lines() {
+  git show "$merge_base:$1" | awk 'END { print NR }'
+}
+
+is_excluded() {
+  case $1 in
+    *.g.dart|*.freezed.dart|\
+    app/lib/l10n/app_localizations.dart|app/lib/l10n/app_localizations_*.dart|\
+    designer_v2/lib/localization/app_localizations.dart|designer_v2/lib/localization/app_localizations_*.dart)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+clean=0
+warnings=0
+errors=0
+skipped=0
+checked=0
+
+while IFS= read -r -d '' status; do
+  IFS= read -r -d '' base_path
+  current_path=$base_path
+  case $status in
+    R*)
+      IFS= read -r -d '' current_path
+      ;;
+  esac
+
+  if is_excluded "$current_path"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+  current_lines=$(count_lines "$current_path")
+  base_lines=''
+  if [[ $status != A* ]] && git cat-file -e "$merge_base:$base_path" 2>/dev/null; then
+    base_lines=$(count_base_lines "$base_path")
+  fi
+
+  current_escaped=$(escape_message "$current_path")
+  current_property=$(escape_property "$current_path")
+  if (( current_lines <= 300 )); then
+    clean=$((clean + 1))
+  elif (( current_lines <= 500 )); then
+    warnings=$((warnings + 1))
+    printf '::warning file=%s,line=1,title=Dart file length::%s has %s lines; soft limit is 300 and hard limit is 500.\n' \
+      "$current_property" "$current_escaped" "$current_lines"
+  elif [[ -z $base_lines ]] || (( base_lines <= 500 )); then
+    errors=$((errors + 1))
+    printf '::error file=%s,line=1,title=Dart file too long::%s has %s lines; new and previously compliant files must stay at or below 500.\n' \
+      "$current_property" "$current_escaped" "$current_lines"
+  elif (( current_lines > base_lines )); then
+    errors=$((errors + 1))
+    printf '::error file=%s,line=1,title=Oversized Dart file grew::%s grew from %s to %s lines; files already over 500 lines may not grow.\n' \
+      "$current_property" "$current_escaped" "$base_lines" "$current_lines"
+  else
+    warnings=$((warnings + 1))
+    printf '::warning file=%s,line=1,title=Grandfathered Dart file::%s is %s lines, down from %s; continue reducing it toward 500.\n' \
+      "$current_property" "$current_escaped" "$current_lines" "$base_lines"
+  fi
+
+done < "$status_file"
+
+printf 'Checked %s Dart files: %s clean, %s warning, %s error, %s generated files skipped.\n' \
+  "$checked" "$clean" "$warnings" "$errors" "$skipped"
+
+if (( errors > 0 )); then
+  exit 1
+fi


### PR DESCRIPTION
## Description

Adds a pull request workflow that checks changed Dart files against a 300-line soft limit and a 500-line hard limit, while excluding generated localization and serialization files. Previously oversized files are grandfathered against growth, and the new check is included in the ready-to-merge workflow requirements.

## Testing Steps

1. Run `bash -n scripts/check-dart-file-lengths`.
2. Run `shellcheck scripts/check-dart-file-lengths`.
3. Run `actionlint .github/workflows/dart_file_lines.yml .github/workflows/ready_to_merge.yml`.
4. Run `scripts/check-dart-file-lengths origin/dev`.
5. Run `scripts/pre-commit-check`.

### PR Checklist

- [x] `scripts/pre-commit-check` passes
